### PR TITLE
Declare new permissions so they are available to CentralAuth

### DIFF
--- a/CreateWiki.php
+++ b/CreateWiki.php
@@ -5,3 +5,9 @@ if ( function_exists( 'wfLoadExtension' ) ) {
 } else {
 	die( 'This version requires MediaWiki 1.25+' );
 }
+
+// We must declare available rights, otherwise they are not available to other extensions, such as CentralAuth
+
+$wgAvailablePermissions[] = 'createwiki';
+$wgAvailablePermissions[] = 'managewiki';
+$wgAvailablePermissions[] = 'managewiki-restricted';


### PR DESCRIPTION
We must declare new permissions otherwise they are not available to other extensions, mainly CentralAuth