### PR TITLE
Update farmer log description

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,7 @@
 	"createwiki-label-submit": "Submit",
 	"createwiki-legend": "Create a wiki",
 	"createwiki-success": "The wiki was successfully created.",
-	"log-description-farmer": "This log tracks wiki requests, wiki creations and everything related to it.",
+	"log-description-farmer": "This log tracks changes to wiki settings.",
 	"logentry-farmer-createwiki": "$1 created the wiki \"$4\"",
 	"logentry-farmer-managewiki": "$1 changed the settings for \"$4\"",
 	"logentry-farmer-requestwiki": "$1 requested the wiki \"$4\" (language: $5; private: $6) in $7",


### PR DESCRIPTION
Currently is meta specific. Updating as the log is used on all wikis now. Wiki Creations and requests only happen on meta. We can customise it on meta directly.