### PR TITLE
Move wgCreateWikiDatabase config to callback

### DIFF
--- a/CreateWiki.hooks.php
+++ b/CreateWiki.hooks.php
@@ -12,7 +12,11 @@ class CreateWikiHooks {
 	}
 
 	public static function onRegistration() {
-		global $wgLogTypes;
+		global $wgLogTypes, $wgCreateWikiDatabase;
+		
+		if ( !isset( $wgCreateWikiDatabase ) ) {
+			$wgCreateWikiDatabase = 'metawiki';
+		}
 
 		if ( !in_array( 'farmer', $wgLogTypes ) ) {
 			$wgLogTypes[] = 'farmer';

--- a/extension.json
+++ b/extension.json
@@ -50,7 +50,6 @@
                 ]
         },
         "config": {
-		"CreateWikiDatabase": "metawiki",
 		"CreateWikiSQLfiles": false,
 		"CreateWikiUseCategories": false,
 		"CreateWikiCategories": false


### PR DESCRIPTION
Reason is in mw 1.31 you cannot specify this config in other extensions otherwise it fails with a hard failure.