### PR TITLE
Return an empty array instead of false in getFormDescriptor

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -45,7 +45,7 @@ class RequestWikiRequestViewer {
 			|| $visibility === 3 && !$wgUser->isAllowed( 'suppressrevision' )
 		) {
 			$context->getOutput()->addWikiMsg( 'requestwikiqueue-requestnotfound' );
-			return false;
+			return [];
 		}
 
 		$status = ( $res->cw_status === 'inreview' ) ? 'In review' : ucfirst( $res->cw_status );


### PR DESCRIPTION
This fixes an issue where a request is not found, but instead of returning an empty array, it returned false, which caused an issue in HTMLForm.php.