### PR TITLE
wikimanager: Stop setting storage_engine to innodb

### DIFF
--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -93,7 +93,6 @@ class WikiManager {
 			]
 		);
 
-		$this->dbw->query( 'SET storage_engine=InnoDB;' );
 		$this->dbw->query( 'CREATE DATABASE ' . $this->dbw->addIdentifierQuotes( $wiki ) . ';' );
 
 		Shell::makeScriptCommand(


### PR DESCRIPTION
it's the default under mysql 5.5+ and MariaDB 10.2+.

Users can set innodb to be the default in the configuration. (which should be preferred).

Bug: T4611