### PR TITLE
Allow $wgCreateWikiBlacklistedSubdomains to be an array

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -92,7 +92,7 @@
 	},
 	"config": {
 		"CreateWikiBlacklistedSubdomains": {
-			"description": "String. Regex to match for a blacklisted subdomain.",
+			"description": "String or array. Regex to match for a blacklisted subdomain.",
 			"public": true,
 			"value": "/ /"
 		},

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -105,6 +105,12 @@ class SpecialRequestWiki extends FormSpecialPage {
 	public function onSubmit( array $formData ) {
 		$subdomain = strtolower( $formData['subdomain'] );
 
+		if ( is_array( $this->config->get( 'CreateWikiBlacklistedSubdomains' ) ) ) {
+			$subdomainBlacklist = '/^(' . implode( '|', $this->config->get( 'CreateWikiBlacklistedSubdomains' ) ) . ')+$/';
+		} else {
+			$subdomainBlacklist = $this->config->get( 'CreateWikiBlacklistedSubdomains' );
+		}
+
 		if ( strpos( $subdomain, $this->config->get( 'CreateWikiSubdomain' ) ) !== false ) {
 			$subdomain = str_replace( '.' . $this->config->get( 'CreateWikiSubdomain' ), '', $subdomain );
 		}
@@ -116,7 +122,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 			$out->addHTML( '<div class="errorbox">' .  $this->msg( 'createwiki-error-notalnum' )->escaped() . '</div>' );
 			wfDebugLog( 'CreateWiki', 'Invalid subdomain entered. Requested: ' . $subdomain );
 			return false;
-		} elseif ( preg_match( $this->config->get( 'CreateWikiBlacklistedSubdomains' ), $subdomain ) ) {
+		} elseif ( preg_match( $subdomainBlacklist, $subdomain ) ) {
 			$out->addHTML( '<div class="errorbox">' . $this->msg( 'createwiki-error-blacklisted' )->escaped() . '</div>' );
 			return false;
 		} else {


### PR DESCRIPTION
So it's easier to add new regex blacklists, and doesn't have one huge string. Feel free to close this if it isn't a good idea to do though.