### PR TITLE
Re-add echo notifications for declined requests

### DIFF
--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -173,20 +173,21 @@ class WikiRequest {
 	public function reopen( User $user, $log = true ) {
 		$this->status = ( $this->status == 'approved' ) ? 'approved' : 'inreview';
 		$this->save();
+
 		if ( $log ) {
 			$this->addComment( 'Updated request.', $user );
 		}
 	}
 
 	private function sendNotification( string $text, User $user, string $type ) {
-		 if ( !$this->config->get( 'CreateWikiUseEchoNotifications' ) ) {
-		 	return;
-		 }
+		if ( !$this->config->get( 'CreateWikiUseEchoNotifications' ) ) {
+			return;
+		}
+
+		$comment = $type == 'declined' ? 'reason' : 'comment';
 
 		// Don't notify the acting user of their action
 		unset( $this->involvedUsers[$user->getId()] );
-
-		$comment = $type == 'declined' ? 'reason' : 'comment';
 
 		foreach ( $this->involvedUsers as $user => $object ) {
 			EchoEvent::create(


### PR DESCRIPTION
Changes the behavior from 06a282b, which completely removed the declined notifications type from sending, this in turn, remains to keep it from sending 2 notifications for declined requests while still supporting the `request-declined` type.

Additionally, Currently, it seems like echo does not send *any* email notifications for declined requests or request comments (reliably) - regardless of email preferences set in Special:Preferences, which is something else that needs looked into also. It does still send web notifications though, but even for declined notifications, it sends that it received a comment, not that it was declined, which is what this fixes.