### PR TITLE
Use textarea type for reason and comment fields

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,7 +22,7 @@
 	"createwiki-error-notsuffixed": "The database name doesn't end in a valid suffix (e.g. 'wiki').",
 	"createwiki-error-swiftcontainernot": "Failed to create swift container for wiki $1",
 	"createwiki-error-usernotcreated": "The requester user was not created on the wiki.",
-	"createwiki-help-reason": "Enter 2-4 sentences describing the topic, scope, and purpose of the wiki you're requesting.",
+	"createwiki-help-reason": "Please enter 2-4 sentences describing the topic, scope, and purpose of the wiki you're requesting.",
 	"createwiki-label-category": "Category:",
 	"createwiki-label-dbname": "Database name:",
 	"createwiki-label-language": "Language:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,6 +22,7 @@
 	"createwiki-error-notsuffixed": "The database name doesn't end in a valid suffix (e.g. 'wiki').",
 	"createwiki-error-swiftcontainernot": "Failed to create swift container for wiki $1",
 	"createwiki-error-usernotcreated": "The requester user was not created on the wiki.",
+	"createwiki-help-reason": "Enter 2-4 sentences describing the topic, scope, and purpose of the wiki you're requesting.",
 	"createwiki-label-category": "Category:",
 	"createwiki-label-dbname": "Database name:",
 	"createwiki-label-language": "Language:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -22,7 +22,7 @@
 	"createwiki-error-notsuffixed": "The database name doesn't end in a valid suffix (e.g. 'wiki').",
 	"createwiki-error-swiftcontainernot": "Failed to create swift container for wiki $1",
 	"createwiki-error-usernotcreated": "The requester user was not created on the wiki.",
-	"createwiki-help-reason": "Please enter 2-4 sentences describing the topic, scope, and purpose of the wiki you're requesting.",
+	"createwiki-help-reason": "Please enter a sufficient summary describing the topic, scope, and purpose of the wiki you're requesting.",
 	"createwiki-label-category": "Category:",
 	"createwiki-label-dbname": "Database name:",
 	"createwiki-label-language": "Language:",

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -67,7 +67,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 6,
+			'rows' => 4,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'default' => $request->getVal( 'wpreason' ),
@@ -99,7 +99,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 		return true;
 	}
 
-	public static function validateDBname( $DBname, $allData ) {
+	public function validateDBname( $DBname, $allData ) {
 		if ( is_null( $DBname ) ) {
 			return true;
 		}

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -67,7 +67,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 4,
+			'rows' => 5,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'default' => $request->getVal( 'wpreason' ),

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -66,10 +66,10 @@ class SpecialCreateWiki extends FormSpecialPage {
 		}
 
 		$formDescriptor['reason'] = [
+			'type' => 'textarea',
+			'rows' => 6,
 			'label-message' => 'createwiki-label-reason',
-			'type' => 'text',
 			'default' => $request->getVal( 'wpreason' ),
-			'size' => 45,
 			'required' => true,
 		];
 
@@ -98,7 +98,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 		return true;
 	}
 
-	public function validateDBname( $DBname, $allData ) {
+	public static function validateDBname( $DBname, $allData ) {
 		if ( is_null( $DBname ) ) {
 			return true;
 		}

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -69,6 +69,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 			'type' => 'textarea',
 			'rows' => 6,
 			'label-message' => 'createwiki-label-reason',
+			'help-message' => 'createwiki-help-reason',
 			'default' => $request->getVal( 'wpreason' ),
 			'required' => true,
 		];

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -67,7 +67,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 5,
+			'rows' => 4,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'default' => $request->getVal( 'wpreason' ),

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -149,6 +149,7 @@ class RequestWikiRequestViewer {
 					'label-message' => 'createwiki-label-category',
 					'options' => $this->config->get( 'CreateWikiCategories' ),
 					'default' => (string)$request->category,
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'edit'
 				];
 			}

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -31,8 +31,6 @@ class RequestWikiRequestViewer {
 		}
 
 		$status = ( $request->getStatus() === 'inreview' ) ? 'In review' : ucfirst( $request->getStatus() );
-		
-		$context->getOutput()->addModules( 'ext.createwiki.oouiform' );
 
 		$formDescriptor = [
 			'sitename' => [
@@ -270,6 +268,8 @@ class RequestWikiRequestViewer {
 		IContextSource $context,
 		$formClass = CreateWikiOOUIForm::class
 	) {
+		$context->getOutput()->addModules( 'ext.createwiki.oouiform' );
+
 		try {
 			$request = new WikiRequest( $id );
 		} catch ( MWException $e ) {

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -77,11 +77,11 @@ class RequestWikiRequestViewer {
 				'default' => (string)$status
 			],
 			'description' => [
-				'label-message' => 'requestwikiqueue-request-header-requestercomment',
 				'type' => 'textarea',
-				'readonly' => true,
-				'section' => 'request',
 				'rows' => 5,
+				'readonly' => true,
+				'label-message' => 'requestwikiqueue-request-header-requestercomment',
+				'section' => 'request',
 				'default' => (string)$request->description,
 				'raw' => true
 			]
@@ -92,7 +92,7 @@ class RequestWikiRequestViewer {
 				'type' => 'textarea',
 				'readonly' => true,
 				'section' => 'comments',
-				'rows' => 3,
+				'rows' => 5,
 				'label' => wfMessage( 'requestwikiqueue-request-header-wikicreatorcomment-withtimestamp' )->rawParams( $comment['user']->getName() )->params( $context->getLanguage()->timeanddate( $comment['timestamp'], true ) )->text(),
 				'default' => $comment['comment']
 			];
@@ -101,7 +101,8 @@ class RequestWikiRequestViewer {
 		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) || $userR->getId() == $request->requester->getId() ) {
 			$formDescriptor += [
 				'comment' => [
-					'type' => 'text',
+					'type' => 'textarea',
+					'rows' => 5,
 					'label-message' => 'requestwikiqueue-request-label-comment',
 					'section' => 'comments'
 				],

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -31,6 +31,8 @@ class RequestWikiRequestViewer {
 		}
 
 		$status = ( $request->getStatus() === 'inreview' ) ? 'In review' : ucfirst( $request->getStatus() );
+		
+		$context->getOutput()->addModules( 'ext.createwiki.oouiform' );
 
 		$formDescriptor = [
 			'sitename' => [

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -78,7 +78,7 @@ class RequestWikiRequestViewer {
 			],
 			'description' => [
 				'type' => 'textarea',
-				'rows' => 4,
+				'rows' => 3,
 				'readonly' => true,
 				'label-message' => 'requestwikiqueue-request-header-requestercomment',
 				'section' => 'request',
@@ -92,9 +92,8 @@ class RequestWikiRequestViewer {
 				'type' => 'textarea',
 				'readonly' => true,
 				'section' => 'comments',
-				'rows' => 4,
+				'rows' => 3,
 				'label' => wfMessage( 'requestwikiqueue-request-header-wikicreatorcomment-withtimestamp' )->rawParams( $comment['user']->getName() )->params( $context->getLanguage()->timeanddate( $comment['timestamp'], true ) )->text(),
-				'cssclass' => 'createwiki-infuse',
 				'default' => $comment['comment']
 			];
 		}
@@ -103,9 +102,8 @@ class RequestWikiRequestViewer {
 			$formDescriptor += [
 				'comment' => [
 					'type' => 'textarea',
-					'rows' => 4,
+					'rows' => 3,
 					'label-message' => 'requestwikiqueue-request-label-comment',
-					'cssclass' => 'createwiki-infuse',
 					'section' => 'comments'
 				],
 				'submit-comment' => [
@@ -138,10 +136,9 @@ class RequestWikiRequestViewer {
 					'label-message' => 'requestwikiqueue-request-header-requestercomment',
 					'type' => 'textarea',
 					'section' => 'edit',
-					'rows' => 4,
+					'rows' => 3,
 					'required' => true,
 					'default' => (string)$request->description,
-					'cssclass' => 'createwiki-infuse',
 					'raw' => true
 				]
 			];
@@ -252,7 +249,7 @@ class RequestWikiRequestViewer {
 				$formDescriptor['reason']['options'] = $this->config->get( 'CreateWikiCannedResponses' );
 			} else {
 				$formDescriptor['reason']['type'] = 'textarea';
-				$formDescriptor['reason']['rows'] = 4;
+				$formDescriptor['reason']['rows'] = 3;
 			}
 
 			if ( $wmError ) {

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -137,6 +137,7 @@ class RequestWikiRequestViewer {
 					'type' => 'textarea',
 					'section' => 'edit',
 					'rows' => 4,
+					'required' => true,
 					'default' => (string)$request->description,
 					'raw' => true
 				]

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -78,7 +78,7 @@ class RequestWikiRequestViewer {
 			],
 			'description' => [
 				'type' => 'textarea',
-				'rows' => 3,
+				'rows' => 4,
 				'readonly' => true,
 				'label-message' => 'requestwikiqueue-request-header-requestercomment',
 				'section' => 'request',
@@ -92,7 +92,7 @@ class RequestWikiRequestViewer {
 				'type' => 'textarea',
 				'readonly' => true,
 				'section' => 'comments',
-				'rows' => 3,
+				'rows' => 4,
 				'label' => wfMessage( 'requestwikiqueue-request-header-wikicreatorcomment-withtimestamp' )->rawParams( $comment['user']->getName() )->params( $context->getLanguage()->timeanddate( $comment['timestamp'], true ) )->text(),
 				'default' => $comment['comment']
 			];
@@ -102,7 +102,7 @@ class RequestWikiRequestViewer {
 			$formDescriptor += [
 				'comment' => [
 					'type' => 'textarea',
-					'rows' => 3,
+					'rows' => 4,
 					'label-message' => 'requestwikiqueue-request-label-comment',
 					'section' => 'comments'
 				],
@@ -136,7 +136,7 @@ class RequestWikiRequestViewer {
 					'label-message' => 'requestwikiqueue-request-header-requestercomment',
 					'type' => 'textarea',
 					'section' => 'edit',
-					'rows' => 3,
+					'rows' => 4,
 					'required' => true,
 					'default' => (string)$request->description,
 					'raw' => true
@@ -249,7 +249,7 @@ class RequestWikiRequestViewer {
 				$formDescriptor['reason']['options'] = $this->config->get( 'CreateWikiCannedResponses' );
 			} else {
 				$formDescriptor['reason']['type'] = 'textarea';
-				$formDescriptor['reason']['rows'] = 3;
+				$formDescriptor['reason']['rows'] = 4;
 			}
 
 			if ( $wmError ) {

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -78,7 +78,7 @@ class RequestWikiRequestViewer {
 			],
 			'description' => [
 				'type' => 'textarea',
-				'rows' => 5,
+				'rows' => 4,
 				'readonly' => true,
 				'label-message' => 'requestwikiqueue-request-header-requestercomment',
 				'section' => 'request',
@@ -92,7 +92,7 @@ class RequestWikiRequestViewer {
 				'type' => 'textarea',
 				'readonly' => true,
 				'section' => 'comments',
-				'rows' => 5,
+				'rows' => 4,
 				'label' => wfMessage( 'requestwikiqueue-request-header-wikicreatorcomment-withtimestamp' )->rawParams( $comment['user']->getName() )->params( $context->getLanguage()->timeanddate( $comment['timestamp'], true ) )->text(),
 				'default' => $comment['comment']
 			];
@@ -102,7 +102,7 @@ class RequestWikiRequestViewer {
 			$formDescriptor += [
 				'comment' => [
 					'type' => 'textarea',
-					'rows' => 5,
+					'rows' => 4,
 					'label-message' => 'requestwikiqueue-request-label-comment',
 					'section' => 'comments'
 				],
@@ -136,7 +136,7 @@ class RequestWikiRequestViewer {
 					'label-message' => 'requestwikiqueue-request-header-requestercomment',
 					'type' => 'textarea',
 					'section' => 'edit',
-					'rows' => 5,
+					'rows' => 4,
 					'default' => (string)$request->description,
 					'raw' => true
 				]
@@ -243,7 +243,7 @@ class RequestWikiRequestViewer {
 				$formDescriptor['reason']['options'] = $this->config->get( 'CreateWikiCannedResponses' );
 			} else {
 				$formDescriptor['reason']['type'] = 'textarea';
-				$formDescriptor['reason']['rows'] = 5;
+				$formDescriptor['reason']['rows'] = 4;
 			}
 
 			if ( $wmError ) {

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -94,6 +94,7 @@ class RequestWikiRequestViewer {
 				'section' => 'comments',
 				'rows' => 4,
 				'label' => wfMessage( 'requestwikiqueue-request-header-wikicreatorcomment-withtimestamp' )->rawParams( $comment['user']->getName() )->params( $context->getLanguage()->timeanddate( $comment['timestamp'], true ) )->text(),
+				'cssclass' => 'createwiki-infuse',
 				'default' => $comment['comment']
 			];
 		}
@@ -104,6 +105,7 @@ class RequestWikiRequestViewer {
 					'type' => 'textarea',
 					'rows' => 4,
 					'label-message' => 'requestwikiqueue-request-label-comment',
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'comments'
 				],
 				'submit-comment' => [
@@ -139,6 +141,7 @@ class RequestWikiRequestViewer {
 					'rows' => 4,
 					'required' => true,
 					'default' => (string)$request->description,
+					'cssclass' => 'createwiki-infuse',
 					'raw' => true
 				]
 			];
@@ -178,6 +181,7 @@ class RequestWikiRequestViewer {
 					'label-message' => 'requestwiki-label-purpose',
 					'options' => $this->config->get( 'CreateWikiPurposes'),
 					'default' => trim( $request->purpose ),
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'edit'
 				];
 			}
@@ -220,6 +224,7 @@ class RequestWikiRequestViewer {
 						wfMessage( 'requestwikiqueue-decline')->text() => 'decline'
 					],
 					'default' => $request->getStatus(),
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'handle'
 				],
 				'visibility' => [
@@ -227,10 +232,12 @@ class RequestWikiRequestViewer {
 					'label-message' => 'requestwikiqueue-request-label-visibility',
 					'options' => array_flip( $visibilityOptions ),
 					'default' => $request->visibility,
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'handle'
 				],
 				'reason' => [
 					'label-message' => 'createwiki-label-reason',
+					'cssclass' => 'createwiki-infuse',
 					'section' => 'handle'
 				],
 				'submit-handle' => [

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -228,7 +228,6 @@ class RequestWikiRequestViewer {
 					'section' => 'handle'
 				],
 				'reason' => [
-					'type' => 'text',
 					'label-message' => 'createwiki-label-reason',
 					'section' => 'handle'
 				],
@@ -242,6 +241,9 @@ class RequestWikiRequestViewer {
 			if ( $this->config->get( 'CreateWikiCannedResponses' ) ) {
 				$formDescriptor['reason']['type'] = 'select';
 				$formDescriptor['reason']['options'] = $this->config->get( 'CreateWikiCannedResponses' );
+			} else {
+				$formDescriptor['reason']['type'] = 'textarea';
+				$formDescriptor['reason']['rows'] = 5;
 			}
 
 			if ( $wmError ) {

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -88,7 +88,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 5,
+			'rows' => 3,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'required' => true,

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -88,7 +88,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 3,
+			'rows' => 4,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'required' => true,

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -88,7 +88,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 6,
+			'rows' => 4,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'required' => true,

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -88,6 +88,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
+			'rows' => 6,
 			'label-message' => 'createwiki-label-reason',
 			'required' => true,
 			'validation-callback' => [ __CLASS__, 'isValidReason' ],

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -90,6 +90,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 			'type' => 'textarea',
 			'rows' => 6,
 			'label-message' => 'createwiki-label-reason',
+			'help-message' => 'createwiki-help-reason',
 			'required' => true,
 			'validation-callback' => [ __CLASS__, 'isValidReason' ],
 		];

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -87,7 +87,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 		}
 
 		$formDescriptor['reason'] = [
-			'type' => 'text',
+			'type' => 'textarea',
 			'label-message' => 'createwiki-label-reason',
 			'required' => true,
 			'validation-callback' => [ __CLASS__, 'isValidReason' ],

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -88,7 +88,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		$formDescriptor['reason'] = [
 			'type' => 'textarea',
-			'rows' => 4,
+			'rows' => 5,
 			'label-message' => 'createwiki-label-reason',
 			'help-message' => 'createwiki-help-reason',
 			'required' => true,

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -179,12 +179,12 @@ class SpecialRequestWiki extends FormSpecialPage {
 			preg_match( "/" . $regex . "/i", $reason, $output );
 
 			if ( is_array( $output ) && count( $output ) >= 1 ) {
-				return wfMessage( 'requestwiki-error-invalidcomment' );
+				return wfMessage( 'requestwiki-error-invalidcomment' )->escaped();
 			}
 		}
 
-		if ( $reason == '' ) {
-			return wfMessage( 'htmlform-required', 'parseinline' );
+		if ( !trim( $reason ) ) {
+			return wfMessage( 'htmlform-required', 'parseinline' )->escaped();
 		}
 
 		return true;

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -89,6 +89,11 @@ class WikiRequest {
 	}
 
 	public function addComment( string $comment, User $user, string $type = 'comment' ) {
+		// don't post empty comments
+		if ( !trim( $comment ) ) {
+			return;
+		}
+
 		$this->dbw->insert(
 			'cw_comments',
 			[


### PR DESCRIPTION
This has been mentioned multiple times so doing this. It also adds a help message to the reason field.

Also makes it so you can't post an empty comment or open a wiki request with a completely empty reason (or contains only whitespace or newlines)