### PR TITLE
Support loading extension/skin entry points automatically

### DIFF
--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -259,10 +259,7 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						$pathInfo = pathinfo( $path );
-						$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-							wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-						);
+						pathinfo( $path )['extension'] === 'php' ? require_once $path : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -251,6 +251,7 @@ class WikiInitialise {
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
+			$require = [];
 			foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 				if ( in_array( $ext['var'], (array)$cacheArray['extensions'] ) &&
 					!in_array( $name, $this->disabledExtensions ) &&
@@ -259,12 +260,14 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? ( $req = require_once $path ) : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'php' ? ( $require[] = $path ) : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}
 
-			return $req ?? true;
+			foreach ( $require as $path ) {
+				require_once $path;
+			}
 		}
 	}
 }

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,8 +152,6 @@ class WikiInitialise {
 			}
 		}
 
-		require_once( '/srv/mediawiki/w/includes/WebStart.php' );
-
 		$reg = new ExtensionRegistry();
 		$queue = array_fill_keys( array_merge(
 				glob( $wgExtensionDirectory . '/*/extension*.json' ),
@@ -162,7 +160,7 @@ class WikiInitialise {
 		true );
 
 		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
-				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
+				array_merge( ...array_values( $wgExtensionCredits ) )
 			)
 		);
 

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -153,11 +153,9 @@ class WikiInitialise {
 		}
 
 		//$reg = new ExtensionRegistry();
-		$config = \MediaWiki\MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'createwiki' );
-
 		$queue = array_fill_keys( array_merge(
-				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
-				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
+				glob( $wgExtensionDirectory . '/*/extension*.json' ),
+				glob( $wgStyleDirectory . '/*/skin.json' )
 			),
 		true );
 
@@ -171,7 +169,7 @@ class WikiInitialise {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
 
-				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+				foreach ( $wgManageWikiExtensions as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
 						 $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -251,21 +251,18 @@ class WikiInitialise {
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
-			$require = [];
 			foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 				if ( in_array( $ext['var'], (array)$cacheArray['extensions'] ) &&
 					!in_array( $name, $this->disabledExtensions ) &&
 					!in_array( $ext['name'], $this->disabledExtensions )
 				) {
-					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
+					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? ( $require[] = $path ) : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'json' ?: ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}
-
-			return $require;
 		}
 	}
 }

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -172,6 +172,10 @@ class WikiInitialise {
 			$this->config->settings[ $ext['var'] ]['default'] = false;
 		}
 
+		global $wgDBname;
+
+		$wgDBname = $this->dbname;
+
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -248,7 +248,7 @@ class WikiInitialise {
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+								wfLoadExtension( $ext['name'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}
 					}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -237,10 +237,6 @@ class WikiInitialise {
 
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 			$this->config->settings[ $ext['var'] ]['default'] = false;
-
-			if ( $ext['entrypoint'] ?? false ) {
-				require_once $ext['entrypoint'];
-			}
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
@@ -251,7 +247,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? null : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? require_once $path; : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -172,10 +172,12 @@ class WikiInitialise {
 
 				foreach ( $this->config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ];
-						$pathInfo = pathinfo( $path );
-						$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
-							wfLoadExtension( pathinfo( dirname( $path ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) );
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						if ( $path ) {
+							$pathInfo = pathinfo( $path );
+							$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
+								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) ) );
+						}
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -247,7 +247,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? require_once $ext['entrypoint'] : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -171,6 +171,9 @@ class WikiInitialise {
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
+				foreach ( $credits as $name ) {
+					$credits[$name]['var'] = $var
+				}
 
 				$path = array_column( $credits, 'path', 'var' )[ $var ] ?? false;
 				if ( $path ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -182,7 +182,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,6 +152,8 @@ class WikiInitialise {
 			}
 		}
 
+		require_once( '/srv/mediawiki/w/includes/WebStart.php' );
+
 		$reg = new ExtensionRegistry();
 		$queue = array_fill_keys( array_merge(
 				glob( $wgExtensionDirectory . '/*/extension*.json' ),

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -153,6 +153,7 @@ class WikiInitialise {
 		}
 
 		// Assign extensions variables now
+		$config = new GlobalVarConfig( 'wg' );
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 			$this->config->settings[ $ext['var'] ]['default'] = false;
 		}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -172,9 +172,9 @@ class WikiInitialise {
 
 				foreach ( $this->config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						// $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
-							$pathInfo = pathinfo( $path );
+						//	$pathInfo = pathinfo( $path );
 							/*$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
 								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
 							);*/

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -174,9 +174,9 @@ class WikiInitialise {
 						 $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							/*$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
+							$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
 								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
-							);*/
+							);
 						}
 					}
 				}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -175,9 +175,9 @@ class WikiInitialise {
 						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? /*require_once $path*/ false : ( $pathInfo['filename'] === 'extension' ?
+							/*$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
 								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
-							);
+							);*/
 						}
 					}
 				}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -236,7 +236,7 @@ class WikiInitialise {
 		$credits = $reg->readFromQueue( $queue )['credits'];
 
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-			$this->config->settings[ $ext['var'] ]['default'] = false;
+			$this->config->settings[ $ext['var'] ]['default'] = true;
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
@@ -248,7 +248,7 @@ class WikiInitialise {
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( $ext['name'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}
 					}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -9,7 +9,7 @@ class WikiInitialise {
 	public $sitename;
 	public $missing = false;
 	public $wikiDBClusters = [];
-	public $disabledExtensions = [];
+	public static $disabledExtensions = [];
 
 	public function __construct() {
 		// Safeguard LocalSettings from being accessed
@@ -247,8 +247,8 @@ class WikiInitialise {
 						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 						if ( $path &&
-							!in_array( $name, $this->disabledExtensions ) &&
-							!in_array( $ext['name'], $this->disabledExtensions )
+							!in_array( $name, self::$disabledExtensions ) &&
+							!in_array( $ext['name'], self::$disabledExtensions )
 						) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -153,9 +153,12 @@ class WikiInitialise {
 		}
 
 		$reg = new ExtensionRegistry();
+
+		$config = MediaWiki\MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'createwiki' );
+
 		$queue = array_fill_keys( array_merge(
-				glob( $wgExtensionDirectory . '/*/extension*.json' ),
-				glob( $wgStyleDirectory . '/*/skin.json' )
+				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
 			),
 		true );
 
@@ -169,7 +172,7 @@ class WikiInitialise {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
 
-				foreach ( $wgManageWikiExtensions as $name => $ext ) {
+				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
 						 $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,10 +152,42 @@ class WikiInitialise {
 			}
 		}
 
+		$reg = new ExtensionRegistry();
+
+		$config = new GlobalVarConfig( 'wg' );
+
+		$queue = array_fill_keys( array_merge(
+				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
+			),
+		true );
+
+		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
+				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
+			)
+		);
+
 		// Assign extensions variables now
+		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+			$this->config->settings[ $ext['var'] ]['default'] = false;
+		}
+
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
+
+				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+					if ( $ext['var'] === $var ) {
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+
+						if ( $path ) {
+							$pathInfo = pathinfo( $path );
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+							);
+						}
+					}
+				}
 			}
 		}
 
@@ -215,43 +247,6 @@ class WikiInitialise {
 					}
 
 					$this->config->settings[$promoteVar][$this->dbname][$group] = $perm['autopromote'];
-				}
-			}
-		}
-	}
-
-	public function readExtensions() {
-		$cacheArray = json_decode( file_get_contents( $this->cacheDir . '/' . $this->dbname . '.json' ), true );
-
-		$reg = new ExtensionRegistry();
-
-		$config = new GlobalVarConfig( 'wg' );
-
-		$queue = array_fill_keys( array_merge(
-				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
-				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
-			),
-		true );
-
-		$credits = $reg->readFromQueue( $queue )['credits'];
-
-		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-			$this->config->settings[ $ext['var'] ]['default'] = true;
-		}
-
-		if ( isset( $cacheArray['extensions'] ) ) {
-			foreach ( (array)$cacheArray['extensions'] as $var ) {
-				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
-
-						if ( $path ) {
-							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-							);
-						}
-					}
 				}
 			}
 		}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -258,8 +258,8 @@ class WikiInitialise {
 				) {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 
-					if ( $path ) {
-						pathinfo( $path )['extension'] === 'json' ?: ExtensionRegistry::getInstance()->queue( $path );
+					if ( $path && pathinfo( $path )['extension'] === 'json' ) {
+						ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -154,7 +154,7 @@ class WikiInitialise {
 
 		$reg = new ExtensionRegistry();
 
-		$config = MediaWiki\MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'createwiki' );
+		$config = new GlobalVarConfig( 'wg' );
 
 		$queue = array_fill_keys( array_merge(
 				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,17 +152,17 @@ class WikiInitialise {
 			}
 		}
 
-		//$reg = new ExtensionRegistry();
+		$reg = new ExtensionRegistry();
 		$queue = array_fill_keys( array_merge(
 				glob( $wgExtensionDirectory . '/*/extension*.json' ),
 				glob( $wgStyleDirectory . '/*/skin.json' )
 			),
 		true );
 
-		/*$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
+		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
 				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
 			)
-		);*/
+		);
 
 		// Assign extensions variables now
 		if ( isset( $cacheArray['extensions'] ) ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -169,7 +169,7 @@ class WikiInitialise {
 		// Assign extensions variables now
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
-				$config->settings[$var][$this->dbname] = true;
+				$this->config->settings[$var][$this->dbname] = true;
 
 				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -163,7 +163,7 @@ class WikiInitialise {
 		true );
 
 		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
-				array_merge( ...array_values( $wgExtensionCredits ) )
+				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
 			)
 		);
 

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,18 +152,6 @@ class WikiInitialise {
 			}
 		}
 
-		$reg = new ExtensionRegistry();
-
-		$config = new GlobalVarConfig( 'wg' );
-
-		$queue = array_fill_keys( array_merge(
-				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
-				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
-			),
-		true );
-
-		$credits = $reg->readFromQueue( $queue )['credits'];
-
 		// Assign extensions variables now
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 			$this->config->settings[ $ext['var'] ]['default'] = false;
@@ -172,19 +160,6 @@ class WikiInitialise {
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
-
-				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
-
-						if ( $path ) {
-							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-							);
-						}
-					}
-				}
 			}
 		}
 
@@ -244,6 +219,39 @@ class WikiInitialise {
 					}
 
 					$this->config->settings[$promoteVar][$this->dbname][$group] = $perm['autopromote'];
+				}
+			}
+		}
+	}
+
+	public function readExtensions() {
+		$cacheArray = json_decode( file_get_contents( $this->cacheDir . '/' . $this->dbname . '.json' ), true );
+
+		$reg = new ExtensionRegistry();
+
+		$config = new GlobalVarConfig( 'wg' );
+
+		$queue = array_fill_keys( array_merge(
+				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
+			),
+		true );
+
+		$credits = $reg->readFromQueue( $queue )['credits'];
+
+		if ( isset( $cacheArray['extensions'] ) ) {
+			foreach ( (array)$cacheArray['extensions'] as $var ) {
+				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+					if ( $ext['var'] === $var ) {
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
+
+						if ( $path ) {
+							$pathInfo = pathinfo( $path );
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+							);
+						}
+					}
 				}
 			}
 		}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -237,6 +237,10 @@ class WikiInitialise {
 
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 			$this->config->settings[ $ext['var'] ]['default'] = false;
+
+			if ( $ext['entrypoint'] ?? false ) {
+				require_once $ext['entrypoint'];
+			}
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
@@ -247,7 +251,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $ext['entrypoint'] : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? null : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -253,7 +253,6 @@ class WikiInitialise {
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 				if ( in_array( $ext['var'], (array)$cacheArray['extensions'] ) &&
-					!in_array( $name, $this->disabledExtensions ) &&
 					!in_array( $ext['name'], $this->disabledExtensions )
 				) {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -259,7 +259,7 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? include $path : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'php' ? require $path : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -172,16 +172,12 @@ class WikiInitialise {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
 
-				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
-						if ( $path ) {
-							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-							);
-						}
-					}
+				$path = array_column( $credits, 'path', 'var' )[ $var ] ?? false;
+				if ( $path ) {
+					$pathInfo = pathinfo( $path );
+					$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
+						wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+					);
 				}
 			}
 		}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -172,7 +172,7 @@ class WikiInitialise {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
 				foreach ( $credits as $name ) {
-					$credits[$name]['var'] = $var
+					$credits[$name]['var'] = $var;
 				}
 
 				$path = array_column( $credits, 'path', 'var' )[ $var ] ?? false;

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -9,7 +9,7 @@ class WikiInitialise {
 	public $sitename;
 	public $missing = false;
 	public $wikiDBClusters = [];
-	public $disabledExtensions;
+	public $disabledExtensions = [];
 
 	public function __construct() {
 		// Safeguard LocalSettings from being accessed

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -178,7 +178,7 @@ class WikiInitialise {
 
 				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -178,7 +178,7 @@ class WikiInitialise {
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) ), $path ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
+								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}
 					}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -259,7 +259,7 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? require_once $path : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'php' ? include_once $path : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -162,10 +162,7 @@ class WikiInitialise {
 			),
 		true );
 
-		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
-				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
-			)
-		);
+		$credits = $reg->readFromQueue( $queue )['credits'];
 
 		// Assign extensions variables now
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
@@ -178,7 +175,7 @@ class WikiInitialise {
 
 				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -263,6 +263,8 @@ class WikiInitialise {
 					}
 				}
 			}
+
+			return $req ?? true;
 		}
 	}
 }

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -175,8 +175,9 @@ class WikiInitialise {
 						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
-								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) ) );
+							$pathInfo['extension'] === 'php' ? /*require_once $path*/ false : ( $pathInfo['filename'] === 'extension' ?
+								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
+							);
 						}
 					}
 				}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -241,20 +241,18 @@ class WikiInitialise {
 		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
-			foreach ( (array)$cacheArray['extensions'] as $var ) {
-				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-					if ( $ext['var'] === $var ) {
-						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
+			foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+				if ( in_array( $ext['var'], (array)$cacheArray['extensions'] ) &&
+					!in_array( $name, $this->disabledExtensions ) &&
+					!in_array( $ext['name'], $this->disabledExtensions )
+				) {
+					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
-						if ( $path &&
-							!in_array( $name, $this->disabledExtensions ) &&
-							!in_array( $ext['name'], $this->disabledExtensions )
-						) {
-							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
-								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-							);
-						}
+					if ( $path ) {
+						$pathInfo = pathinfo( $path );
+						$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+						);
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -153,11 +153,6 @@ class WikiInitialise {
 		}
 
 		// Assign extensions variables now
-		$config = new GlobalVarConfig( 'wg' );
-		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
-			$this->config->settings[ $ext['var'] ]['default'] = false;
-		}
-
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
@@ -239,6 +234,10 @@ class WikiInitialise {
 		true );
 
 		$credits = $reg->readFromQueue( $queue )['credits'];
+
+		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+			$this->config->settings[ $ext['var'] ]['default'] = false;
+		}
 
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -247,7 +247,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? null : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -9,7 +9,7 @@ class WikiInitialise {
 	public $sitename;
 	public $missing = false;
 	public $wikiDBClusters = [];
-	public static $disabledExtensions = [];
+	public $disabledExtensions;
 
 	public function __construct() {
 		// Safeguard LocalSettings from being accessed
@@ -247,8 +247,8 @@ class WikiInitialise {
 						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 						if ( $path &&
-							!in_array( $name, self::$disabledExtensions ) &&
-							!in_array( $ext['name'], self::$disabledExtensions )
+							!in_array( $name, $this->disabledExtensions ) &&
+							!in_array( $ext['name'], $this->disabledExtensions )
 						) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,6 +152,8 @@ class WikiInitialise {
 			}
 		}
 
+		require_once( '/srv/mediawiki/w/includes/WebStart.php' );
+
 		$reg = new ExtensionRegistry();
 
 		$queue = array_fill_keys( array_merge(

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -265,9 +265,7 @@ class WikiInitialise {
 				}
 			}
 
-			foreach ( $require as $path ) {
-				require_once $path;
-			}
+			return $require;
 		}
 	}
 }

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,31 +152,30 @@ class WikiInitialise {
 			}
 		}
 
-		require_once( '/srv/mediawiki/w/includes/WebStart.php' );
-
 		$reg = new ExtensionRegistry();
+		$config = \MediaWiki\MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'createwiki' );
 
 		$queue = array_fill_keys( array_merge(
-				glob( $this->config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
-				glob( $this->config->get( 'StyleDirectory' ) . '/*/skin.json' )
+				glob( $config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $config->get( 'StyleDirectory' ) . '/*/skin.json' )
 			),
 		true );
 
 		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
-				array_merge( ...array_values( $this->config->get( 'ExtensionCredits' ) ) )
+				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
 			)
 		);
 
 		// Assign extensions variables now
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
-				$this->config->settings[$var][$this->dbname] = true;
+				$config->settings[$var][$this->dbname] = true;
 
-				foreach ( $this->config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						// $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						 $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
-						//	$pathInfo = pathinfo( $path );
+							$pathInfo = pathinfo( $path );
 							/*$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
 								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
 							);*/

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -259,7 +259,7 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? require $path : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'php' ? ( $req = require_once $path ) : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,7 +152,7 @@ class WikiInitialise {
 			}
 		}
 
-		$reg = new ExtensionRegistry();
+		//$reg = new ExtensionRegistry();
 		$config = \MediaWiki\MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'createwiki' );
 
 		$queue = array_fill_keys( array_merge(
@@ -161,10 +161,10 @@ class WikiInitialise {
 			),
 		true );
 
-		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
+		/*$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
 				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
 			)
-		);
+		);*/
 
 		// Assign extensions variables now
 		if ( isset( $cacheArray['extensions'] ) ) {

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -168,6 +168,10 @@ class WikiInitialise {
 		);
 
 		// Assign extensions variables now
+		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+			$this->config->settings[ $ext['var'] ]['default'] = false;
+		}
+
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -171,16 +171,18 @@ class WikiInitialise {
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
-				foreach ( $credits as $name ) {
-					$credits[$name]['var'] = $var;
-				}
 
-				$path = array_column( $credits, 'path', 'var' )[ $var ] ?? false;
-				if ( $path ) {
-					$pathInfo = pathinfo( $path );
-					$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
-						wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
-					);
+				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+					if ( $ext['var'] === $var ) {
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+
+						if ( $path ) {
+							$pathInfo = pathinfo( $path );
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
+								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
+							);
+						}
+					}
 				}
 			}
 		}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -221,7 +221,7 @@ class WikiInitialise {
 		}
 	}
 
-	public function readExtensions() {
+	public function loadExtensions() {
 		$cacheArray = json_decode( file_get_contents( $this->cacheDir . '/' . $this->dbname . '.json' ), true );
 
 		$config = new GlobalVarConfig( 'wg' );

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -174,11 +174,11 @@ class WikiInitialise {
 
 				foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 					if ( $ext['var'] === $var ) {
-						 $path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? false;
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
-								wfLoadExtension( pathinfo( dirname( $path ) ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match('/extension(.*)/', $pathInfo['filename'] ) ?
+								wfLoadExtension( pathinfo( dirname( $path ) ), $path ) : wfLoadSkin( pathinfo( dirname( $path ) ) )
 							);
 						}
 					}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -247,7 +247,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? null : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -259,7 +259,7 @@ class WikiInitialise {
 					$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
 					if ( $path ) {
-						pathinfo( $path )['extension'] === 'php' ? include_once $path : ExtensionRegistry::getInstance()->queue( $path );
+						pathinfo( $path )['extension'] === 'php' ? include $path : ExtensionRegistry::getInstance()->queue( $path );
 					}
 				}
 			}

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -152,10 +152,32 @@ class WikiInitialise {
 			}
 		}
 
+		$reg = new ExtensionRegistry();
+
+		$queue = array_fill_keys( array_merge(
+				glob( $this->config->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $this->config->get( 'StyleDirectory' ) . '/*/skin.json' )
+			),
+		true );
+
+		$credits = array_merge( $reg->readFromQueue( $queue )['credits'], array_values(
+				array_merge( ...array_values( $this->config->get( 'ExtensionCredits' ) ) )
+			)
+		);
+
 		// Assign extensions variables now
 		if ( isset( $cacheArray['extensions'] ) ) {
 			foreach ( (array)$cacheArray['extensions'] as $var ) {
 				$this->config->settings[$var][$this->dbname] = true;
+
+				foreach ( $this->config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
+					if ( $ext['var'] === $var ) {
+						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ];
+						$pathInfo = pathinfo( $path );
+						$pathInfo['extension'] === 'php' ? require_once $path : ( $pathInfo['filename'] === 'extension' ?
+							wfLoadExtension( pathinfo( dirname( $path ) ) : wfLoadSkin( pathinfo( dirname( $path ) ) );
+					}
+				}
 			}
 		}
 

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -9,6 +9,7 @@ class WikiInitialise {
 	public $sitename;
 	public $missing = false;
 	public $wikiDBClusters = [];
+	public $disabledExtensions = [];
 
 	public function __construct() {
 		// Safeguard LocalSettings from being accessed
@@ -245,7 +246,10 @@ class WikiInitialise {
 					if ( $ext['var'] === $var ) {
 						$path = array_column( $credits, 'path', 'name' )[ $ext['name'] ] ?? $ext['entrypoint'] ?? false;
 
-						if ( $path ) {
+						if ( $path &&
+							!in_array( $name, $this->disabledExtensions ) &&
+							!in_array( $ext['name'], $this->disabledExtensions )
+						) {
 							$pathInfo = pathinfo( $path );
 							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -224,8 +224,6 @@ class WikiInitialise {
 	public function readExtensions() {
 		$cacheArray = json_decode( file_get_contents( $this->cacheDir . '/' . $this->dbname . '.json' ), true );
 
-		$reg = new ExtensionRegistry();
-
 		$config = new GlobalVarConfig( 'wg' );
 
 		$queue = array_fill_keys( array_merge(
@@ -234,7 +232,19 @@ class WikiInitialise {
 			),
 		true );
 
-		$credits = $reg->readFromQueue( $queue )['credits'];
+		$processor = new ExtensionProcessor();
+
+		foreach ( $queue as $path => $mtime ) {
+			$json = file_get_contents( $path );
+			$info = json_decode( $json, true );
+			$version = $info['manifest_version'];
+
+			$processor->extractInfo( $path, $info, $version );
+		}
+
+		$data = $processor->getExtractedInfo();
+
+		$credits = $data['credits'];
 
 		foreach ( $config->get( 'ManageWikiExtensions' ) as $name => $ext ) {
 			$this->config->settings[ $ext['var'] ]['default'] = false;

--- a/includes/WikiInitialise.php
+++ b/includes/WikiInitialise.php
@@ -247,7 +247,7 @@ class WikiInitialise {
 
 						if ( $path ) {
 							$pathInfo = pathinfo( $path );
-							$pathInfo['extension'] === 'php' ? require_once $path; : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
+							$pathInfo['extension'] === 'php' ? require_once $path : ( preg_match( '/extension(.*)/', $pathInfo['filename'] ) ?
 								wfLoadExtension( pathinfo( dirname( $path ) )['filename'], $path ) : wfLoadSkin( pathinfo( dirname( $path ) )['filename'] )
 							);
 						}


### PR DESCRIPTION
* miraheze/mw-config#3991 adds implementation for this.

**Notes:**
* To enable automatic loading of extensions, `$wi->loadExtensions()` will be needed in LocalSettings.php.
* This does not support extensions loaded through a PHP entrypoint.
* Extensions can still be disabled by adding their **ExtensionRegistry** name to the `$wi->disabledExtensions` array in LocalSettings.php.
