### PR TITLE
Reset wiki cache when creating a wiki.

### DIFF
--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -117,6 +117,9 @@ class WikiManager {
 			]
 		);
 
+		$cWJ = new CreateWikiJson( $wiki );
+		$cWJ->resetWiki();
+
 		$this->recacheJson();
 
 		foreach ( $this->config->get( 'CreateWikiSQLfiles' ) as $sqlfile ) {


### PR DESCRIPTION
For some reason errors occur when recreating a previously dropped wiki, clearing the wiki cache appeared to solve that, so do it on creation.