### PR TITLE
Fix regex for checking the AI approval blacklist

### DIFF
--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -36,7 +36,7 @@ class RequestWikiAIJob extends Job {
 	}
 
 	private function canAutoApprove( $config ) {
-		$descriptionBlacklist = '/^(' . implode( '|', $config->get( 'CreateWikiAutoApprovalBlacklist' ) ) . ')+$/';
+		$descriptionBlacklist = '/(' . implode( '|', $config->get( 'CreateWikiAutoApprovalBlacklist' ) ) . ')+/';
 		if ( preg_match( $descriptionBlacklist, strtolower( $this->params['description'] ) ) ) {
 			return false;
 		}


### PR DESCRIPTION
We don't want the regex to have to match exactly, but rather contained within.