### PR TITLE
[Performance] only connect to database if actually used in CreateWikiJson

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -13,25 +13,11 @@ jobs:
     strategy:
       matrix:
         include:
-          # Latest stable MediaWiki - PHP 7.3 (phan)
-          - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
-            experimental: false
-            stage: phan
-
           # Latest stable MediaWiki - PHP 7.4 (phan)
           - mw: 'REL1_37'
             php: 7.4
             php-docker: 74
             experimental: false
-            stage: phan
-
-          # Latest MediaWiki master - PHP 7.3 (phan)
-          - mw: 'master'
-            php: 7.3
-            php-docker: 73
-            experimental: true
             stage: phan
 
           # Latest MediaWiki master - PHP 7.4 (phan)
@@ -41,24 +27,10 @@ jobs:
             experimental: true
             stage: phan
 
-          # Latest stable MediaWiki - PHP 7.3 (phpunit-unit)
-          - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
-            experimental: false
-            stage: phpunit-unit
-
           # Latest stable MediaWiki - PHP 7.4 (phpunit-unit)
           - mw: 'REL1_37'
             php: 7.4
             php-docker: 74
-            experimental: false
-            stage: phpunit-unit
-
-          # Latest MediaWiki master - PHP 7.3 (phpunit-unit)
-          - mw: 'master'
-            php: 7.3
-            php-docker: 73
             experimental: false
             stage: phpunit-unit
 
@@ -69,24 +41,10 @@ jobs:
             experimental: false
             stage: phpunit-unit
 
-          # Latest stable MediaWiki - PHP 7.3 (phpunit)
-          - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
-            experimental: false
-            stage: phpunit
-
           # Latest stable MediaWiki - PHP 7.4 (phpunit)
           - mw: 'REL1_37'
             php: 7.4
             php-docker: 74
-            experimental: false
-            stage: phpunit
-
-          # Latest MediaWiki master - PHP 7.3 (phpunit)
-          - mw: 'master'
-            php: 7.3
-            php-docker: 73
             experimental: false
             stage: phpunit
 
@@ -97,45 +55,45 @@ jobs:
             experimental: false
             stage: phpunit
 
-          # Latest stable MediaWiki - PHP 7.3 (selenium)
+          # Latest stable MediaWiki - PHP 7.4 (selenium)
           - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: selenium
 
-          # Latest MediaWiki master - PHP 7.3 (selenium)
+          # Latest MediaWiki master - PHP 7.4 (selenium)
           - mw: 'master'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: selenium
 
-          # Latest stable MediaWiki - PHP 7.3 (qunit)
+          # Latest stable MediaWiki - PHP 7.4 (qunit)
           - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: qunit
 
-          # Latest MediaWiki master - PHP 7.3 (qunit)
+          # Latest MediaWiki master - PHP 7.4 (qunit)
           - mw: 'master'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: qunit
 
-          # Latest stable MediaWiki - PHP 7.3 (npm-test)
+          # Latest stable MediaWiki - PHP 7.4 (npm-test)
           - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: npm-test
   
-          # Latest stable MediaWiki - PHP 7.3 (composer-test)
+          # Latest stable MediaWiki - PHP 7.4 (composer-test)
           - mw: 'REL1_37'
-            php: 7.3
-            php-docker: 73
+            php: 7.4
+            php-docker: 74
             experimental: false
             stage: composer-test
 

--- a/extension.json
+++ b/extension.json
@@ -11,7 +11,10 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.37.0"
+		"MediaWiki": ">= 1.37.0",
+		"platform": {
+			"php": ">= 7.4"
+		}
 	},
 	"AvailableRights": [
 		"createwiki",

--- a/includes/CreateWikiJson.php
+++ b/includes/CreateWikiJson.php
@@ -28,25 +28,19 @@ class CreateWikiJson {
 		$this->wikiTimestamp = (int)$this->cache->get( $this->cache->makeGlobalKey( 'CreateWiki', $wiki ) );
 		AtEase::restoreWarnings();
 
-		$this->dbr = null;
 		if ( !$this->databaseTimestamp ) {
-			$this->dbr = wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-			$this->initTime = $this->dbr->timestamp();
-
 			$this->resetDatabaseList();
 		}
 
 		if ( !$this->wikiTimestamp ) {
-			if ( !$this->dbr ) {
-				$this->dbr = wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-				$this->initTime = $this->dbr->timestamp();
-			}
-
 			$this->resetWiki();
 		}
 	}
 
 	public function resetWiki() {
+		$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
+		$this->initTime ??= $this->dbr->timestamp();
+
 		$this->cache->set( $this->cache->makeGlobalKey( 'CreateWiki', $this->wiki ), $this->initTime );
 
 		// Rather than destroy object, let's fake the cache timestamp
@@ -54,6 +48,9 @@ class CreateWikiJson {
 	}
 
 	public function resetDatabaseList() {
+		$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
+		$this->initTime ??= $this->dbr->timestamp();
+
 		$this->cache->set( $this->cache->makeGlobalKey( 'CreateWiki', 'databases' ), $this->initTime );
 
 		// Rather than destroy object, let's fake the catch timestamp
@@ -64,17 +61,13 @@ class CreateWikiJson {
 		$changes = $this->newChanges();
 
 		if ( $changes['databases'] ) {
-			if ( !$this->dbr ) {
-				$this->dbr = wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-			}
+			$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 
 			$this->generateDatabaseList();
 		}
 
 		if ( $changes['wiki'] ) {
-			if ( !$this->dbr ) {
-				$this->dbr = wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-			}
+			$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 
 			$this->generateWiki();
 		}


### PR DESCRIPTION
## Performance

### Evidence:

```ps
  9.43% 76.251      3 - Wikimedia\Rdbms\Database::initConnection
  9.43% 76.227      3 - Wikimedia\Rdbms\Database::doInitConnection
  9.43% 76.213      3 - Wikimedia\Rdbms\DatabaseMysqlBase::open
  9.38% 75.809     25 - Wikimedia\Rdbms\LoadBalancer::getMaintenanceConnectionRef
  9.22% 74.534     17 - wfGetDB
  9.06% 73.193      1 - MediaWiki\HookContainer\HookRunner::onSetupAfterCache
  9.04% 73.094      1 - CreateWikiHooks::onSetupAfterCache
  9.00% 72.732     34 - Wikimedia\Services\ServiceContainer::{closure}
  8.80% 71.090      1 - CreateWikiJson::__construct
```

Afterwords, I can't even find that in profile. Additionally, there is currently a lot of logs within Graylog, relating to DB connection errors, with CreateWikiJson, and CreateWikiHooks, this would hopefully prevent them:
```ps
Cannot access the database: Connection timed out (db101) (db101)
from /srv/mediawiki/w/includes/libs/rdbms/loadbalancer/LoadBalancer.php(1513)
#0 /srv/mediawiki/w/includes/libs/rdbms/loadbalancer/LoadBalancer.php(991): Wikimedia\Rdbms\LoadBalancer->reportConnectionError()
#1 /srv/mediawiki/w/includes/libs/rdbms/loadbalancer/LoadBalancer.php(963): Wikimedia\Rdbms\LoadBalancer->getServerConnection(integer, string, integer)
#2 /srv/mediawiki/w/includes/libs/rdbms/loadbalancer/LoadBalancer.php(1128): Wikimedia\Rdbms\LoadBalancer->getConnection(integer, array, string, integer)
#3 /srv/mediawiki/w/includes/GlobalFunctions.php(2234): Wikimedia\Rdbms\LoadBalancer->getMaintenanceConnectionRef(integer, array, string)
#4 /srv/mediawiki/w/extensions/CreateWiki/includes/CreateWikiJson.php(20): wfGetDB(integer, array, string)
#5 /srv/mediawiki/w/extensions/CreateWiki/includes/CreateWikiHooks.php(113): CreateWikiJson->__construct(string)
#6 /srv/mediawiki/w/includes/HookContainer/HookContainer.php(338): CreateWikiHooks::onSetupAfterCache()
#7 /srv/mediawiki/w/includes/HookContainer/HookContainer.php(137): MediaWiki\HookContainer\HookContainer->callLegacyHook(string, array, array, array)
#8 /srv/mediawiki/w/includes/HookContainer/HookRunner.php(3337): MediaWiki\HookContainer\HookContainer->run(string, array)
#9 /srv/mediawiki/w/includes/Setup.php(732): MediaWiki\HookContainer\HookRunner->onSetupAfterCache()
#10 /srv/mediawiki/w/includes/WebStart.php(90): require_once(string)
#11 /srv/mediawiki/w/index.php(44): require(string)
#12 {main}
```
### Note:
This drops less than PHP 7.4 support also, requiring PHP 7.4+ due to the nicer code standards of being able to use `??=`, added in PHP 7.4, and the fact the Miraheze is now using PHP 7.4. I am unsure on external usage that this would impact.