### PR TITLE
Add hook to support modifying available database lists

### DIFF
--- a/includes/CreateWikiJson.php
+++ b/includes/CreateWikiJson.php
@@ -81,7 +81,7 @@ class CreateWikiJson {
 				'wiki_dbname',
 				'wiki_deleted',
 				'wiki_url',
-				'wiki_sitename'
+				'wiki_sitename',
 			]
 		);
 
@@ -92,12 +92,12 @@ class CreateWikiJson {
 			if ( $wiki->wiki_deleted == 1 ) {
 				$deletedList[$wiki->wiki_dbname] = [
 					's' => $wiki->wiki_sitename,
-					'c' => $wiki->wiki_dbcluster
+					'c' => $wiki->wiki_dbcluster,
 				];
 			} else {
 				$combiList[$wiki->wiki_dbname] = [
 					's' => $wiki->wiki_sitename,
-					'c' => $wiki->wiki_dbcluster
+					'c' => $wiki->wiki_dbcluster,
 				];
 
 				if ( $wiki->wiki_url !== null ) {
@@ -107,12 +107,12 @@ class CreateWikiJson {
 		}
 
 		$databaseLists = [
+			'databases' => [
+				'combi' => $combiList,
+			],
 			'deleted' => [
 				'deleted' => 'databases',
 				'databases' => $deletedList,
-			],
-			'databases' => [
-				'combi' => $combiList,
 			],
 		];
 


### PR DESCRIPTION
Should allow adding additional database lists or modify existing ones. This is primarily to support adding database lists for beta.

Example of what we should be able to do to achieve this, if I did this PR correctly:
```php
public static function onCreateWikiJsonGenerateDatabaseList( &$databaseLists ) {
	$dbr = wfGetDB( DB_REPLICA, [], 'testglobal' );
	$allBetaWikis = $dbr->select(
		'cw_wikis',
		[
			'wiki_dbcluster',
			'wiki_dbname',
			'wiki_deleted',
			'wiki_url',
			'wiki_sitename'
		]
	);

	$combiList = [];
	$deletedList = [];

	foreach ( $allBetaWikis as $wiki ) {
		if ( $wiki->wiki_deleted == 1 ) {
			$deletedList[$wiki->wiki_dbname] = [
				's' => $wiki->wiki_sitename,
				'c' => $wiki->wiki_dbcluster
			];
		} else {
			$combiList[$wiki->wiki_dbname] = [
				's' => $wiki->wiki_sitename,
				'c' => $wiki->wiki_dbcluster
			];

			if ( $wiki->wiki_url !== null ) {
				$combiList[$wiki->wiki_dbname]['u'] = $wiki->wiki_url;
			}
		}
	}

	$databaseLists += [
		'beta' => [
			'combi' => $combiList,
		],
		'deleted-beta' => [
			'deleted' => 'databases',
			'databases' => $deletedList,
		],
	];
}
```