### PR TITLE
Fix WikiManager::delete

### DIFF
--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
+		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,10 +205,8 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force ) {
-			if ( !( $deletedWiki && ( $unixNow - $unixDeletion ) > ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
-				return "Wiki {$wiki} can not be deleted yet.";
-			}
+		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
+			return "Wiki {$wiki} can not be deleted yet.";
 		}
 
 		foreach ( $this->tables as $table => $selector ) {

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
+		if ( !$force && ( !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( ( !$force && !$deletedWiki ) && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
+		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && ( !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
+		if ( ( !$force && !$deletedWiki ) && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
+		if ( !$force && !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -206,7 +206,7 @@ class WikiManager {
 
 		// Return error if: wiki is not deleted, force is not used & wiki
 		if ( !$force ) {
-			if ( ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) || !$deletedWiki ) {
+			if ( !( $deletedWiki && ( $unixNow - $unixDeletion ) > ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
 				return "Wiki {$wiki} can not be deleted yet.";
 			}
 		}

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
+		if ( !$force && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) || !$deletedWiki ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && !$deletedWiki && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
+		if ( !$force && !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,8 +205,10 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) || !$deletedWiki ) {
-			return "Wiki {$wiki} can not be deleted yet.";
+		if ( !$force ) {
+			if ( ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) || !$deletedWiki ) {
+				return "Wiki {$wiki} can not be deleted yet.";
+			}
 		}
 
 		foreach ( $this->tables as $table => $selector ) {

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -205,7 +205,7 @@ class WikiManager {
 		$deletedWiki = (bool)$row->wiki_deleted;
 
 		// Return error if: wiki is not deleted, force is not used & wiki
-		if ( !$force && !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) {
+		if ( !$force && ( !$deletedWiki || ( $unixNow - $unixDeletion ) < ( (int)$this->config->get( 'CreateWikiStateDays' )['deleted'] * 86400 ) ) ) {
 			return "Wiki {$wiki} can not be deleted yet.";
 		}
 

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -134,6 +134,9 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
 		$this->assertTrue( self::wikiExists( 'deletewikitest' ) );
+
+		$remoteWiki->undelete();
+		$remoteWiki->commit();
 	}
 
 	/**

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -143,12 +143,13 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
-		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
+		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] )
+
+		$remoteWiki->delete();
 
 		$wikiManager = new WikiManager( 'deletewikitest' );
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
 
-		$remoteWiki->delete();
 		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -141,12 +141,16 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	 */
 	public function testDeleteEligible() {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
-		$remoteWiki->delete();
-
-		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
 		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
+
+		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
+
+		$remoteWiki->delete();
+		$remoteWiki->commit();
+
+		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 
 		$wikiManager = new WikiManager( 'deletewikitest' );
 

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -143,18 +143,17 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::delete
 	 */
 	public function testDeleteEligible() {
+		$wikiManager = new WikiManager( 'deletewikitest' );
+		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
+
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 		$remoteWiki->delete();
+		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
 		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
-
-		$wikiManager = new WikiManager( 'deletewikitest' );
-		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
-
-		$remoteWiki->commit();
 
 		$this->assertNull( $wikiManager->delete() );
 		$this->assertFalse( self::wikiExists( 'deletewikitest' ) );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -144,7 +144,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$remoteWiki->delete();
 
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
-		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] )
+		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
 
 		$wikiManager = new WikiManager( 'deletewikitest' );
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -141,11 +141,10 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	 */
 	public function testDeleteEligible() {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
+		$remoteWiki->delete();
 
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
 		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] )
-
-		$remoteWiki->delete();
 
 		$wikiManager = new WikiManager( 'deletewikitest' );
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -145,14 +145,13 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
 		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
 
+		$wikiManager = new WikiManager( 'deletewikitest' );
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
 
 		$remoteWiki->delete();
 		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
-
-		$wikiManager = new WikiManager( 'deletewikitest' );
 
 		$this->assertNull( $wikiManager->delete() );
 		$this->assertFalse( self::wikiExists( 'deletewikitest' ) );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -143,6 +143,8 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 		$remoteWiki->delete();
 
+		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
+
 		$eligibleTimestamp = wfTimestamp( TS_MW, wfTimestamp( TS_UNIX, $remoteWiki->isDeleted() ) - ( 86400 * 8 ) );
 		$this->db->update( 'cw_wikis', [ 'wiki_deleted_timestamp' => $eligibleTimestamp ], [ 'wiki_dbname' => 'deletewikitest' ] );
 
@@ -150,8 +152,6 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$this->assertSame( 'Wiki deletewikitest can not be deleted yet.', $wikiManager->delete() );
 
 		$remoteWiki->commit();
-
-		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 
 		$this->assertNull( $wikiManager->delete() );
 		$this->assertFalse( self::wikiExists( 'deletewikitest' ) );

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -126,6 +126,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 		$remoteWiki->delete();
+		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 
@@ -141,6 +142,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	public function testDeleteEligible() {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 		$remoteWiki->delete();
+		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -142,7 +142,6 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	public function testDeleteEligible() {
 		$remoteWiki = new RemoteWiki( 'deletewikitest' );
 		$remoteWiki->delete();
-		$remoteWiki->commit();
 
 		$this->assertTrue( (bool)$remoteWiki->isDeleted() );
 


### PR DESCRIPTION
Messed up logic. If the wiki is marked as deleted, it always fails to run WikiManager::delete.