### PR TITLE
Create new CreateWikiRegexConstraint class

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -313,7 +313,7 @@ jobs:
               --color
           elif [ "${{ matrix.stage }}" == 'coverage' ] && [ -d src/extensions/"${{ github.event.repository.name }}"/tests/phpunit ]; then
             docker run \
-              --entrypoint quibble-with-apache \
+              --entrypoint quibble-with-supervisord \
               -e ZUUL_PROJECT=mediawiki/extensions/"${{ github.event.repository.name }}" \
               -v "$(pwd)"/cache:/cache \
               -v "$(pwd)"/src:/workspace/src \
@@ -324,7 +324,7 @@ jobs:
               -c mwext-phpunit-coverage
           elif [ "${{ matrix.stage }}" != 'coverage' ]; then
             docker run \
-              --entrypoint quibble-with-apache \
+              --entrypoint quibble-with-supervisord \
               -e ZUUL_PROJECT=mediawiki/extensions/"${{ github.event.repository.name }}" \
               -v "$(pwd)"/cache:/cache \
               -v "$(pwd)"/src:/workspace/src \

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -101,9 +101,9 @@ class CreateWikiRegexConstraint {
 			if ( self::validateRegexes( [ $regex ] ) ) {
 				return $regex;
 			}
-		}
 
-		wfWarn( 'Contains invalid regex.' );
+			wfWarn( 'Contains invalid regex.' );
+		}
 
 		return '';
 	}

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -21,6 +21,19 @@ class CreateWikiRegexConstraint {
 	}
 
 	/**
+	 * @param array &$regexes
+	 */
+	private static function filterInvalidRegexes( &$regexes ) {
+		foreach ( $regexes as $regex ) {
+			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
+				wfWarn( 'Contains invalid regex.' );
+
+				unset( $regexes[$regex] );
+			}
+		}
+	}
+
+	/**
 	 * @param array $lines
 	 * @return array
 	 */
@@ -33,17 +46,44 @@ class CreateWikiRegexConstraint {
 	}
 
 	/**
-	 * @param array $lines
+	 * @param string $text
 	 * @return array
 	 */
-	private static function regexesFromText( $lines ) {
+	private static function regexesFromText( $text ) {
+		$lines = explode( "\n", $text );
 		$regexes = self::cleanLines( $lines );
 
-		if ( self::validateRegexes( $regexes ) ) {
-			return $regexes;
+		if ( !self::validateRegexes( $regexes ) ) {
+			wfWarn( 'Contains invalid regex.' );
 		}
 
-		return [];
+		return $regexes;
+	}
+
+	/**
+	 * @param array $regexes
+	 * @param string $start
+	 * @param string $end
+	 * @return string
+	 */
+	public static function regexFromArray( $regexes, $start, $end ) {
+		if ( empty( $regexes ) ) {
+			return '';
+		}
+
+		self::filterInvalidRegexes( $regexes );
+
+		if ( !empty( $regexes ) ) {
+			$regex = $start . implode( '|', $regexes ) . $end;
+
+			if ( self::validateRegexes( [ $regex ] ) ) {
+				return $regex;
+			}
+		}
+
+		wfWarn( 'Contains invalid regex.' );
+
+		return '';
 	}
 
 	/**

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -10,7 +10,7 @@ class CreateWikiRegexConstraint {
 	 * @param string $regex invalid regex to log for
 	 * @param string $name name of regex caller (config or message key) to log for
 	 */
-	private static function logInvalidRegex( $regex, $name ) {
+	private static function warnInvalidRegex( $regex, $name ) {
 		LoggerFactory::getInstance( 'CreateWiki' )->warning(
 			'{name} contains invalid regex',
 			[
@@ -31,7 +31,7 @@ class CreateWikiRegexConstraint {
 		$regexes = array_filter( $regexes, static function ( $regex ) use ( $name, $start, $end ) {
 			if ( !StringUtils::isValidPCRERegex( $start . $regex . $end ) ) {
 				if ( $name ) {
-					self::logInvalidRegex( $regex, $name );
+					self::warnInvalidRegex( $regex, $name );
 				}
 
 				return false;
@@ -93,7 +93,7 @@ class CreateWikiRegexConstraint {
 			}
 
 			if ( $name ) {
-				self::logInvalidRegex( $regex, $name );
+				self::warnInvalidRegex( $regex, $name );
 			}
 		}
 
@@ -116,7 +116,7 @@ class CreateWikiRegexConstraint {
 			}
 
 			if ( $name ) {
-				self::logInvalidRegex( $regex, $name );
+				self::warnInvalidRegex( $regex, $name );
 			}
 		}
 

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -11,7 +11,7 @@ class CreateWikiRegexConstraint {
 	 * @param string $name name of regex caller (config or message key) to log for
 	 */
 	private static function logInvalidRegex( $regex, $name ) {
-		LoggerFactory::getInstance( 'CreateWiki' )->info(
+		LoggerFactory::getInstance( 'CreateWiki' )->warn(
 			'{name} contains invalid regex',
 			[
 				'name' => $name,

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -37,8 +37,7 @@ class CreateWikiRegexConstraint {
 	 * @return array
 	 */
 	private static function regexesFromText( $lines ) {
-		$lines = self::cleanLines( $lines );
-		$regexes = explode( "\n", $lines );
+		$regexes = self::cleanLines( $lines );
 
 		if ( self::validateRegexes( $regexes ) ) {
 			return $regexes;
@@ -55,7 +54,7 @@ class CreateWikiRegexConstraint {
 		$message = wfMessage( $key )->inContentLanguage();
 
 		if ( !$message->isDisabled() ) {
-			return self::regexesFromText( $message->plain() );
+			return self::regexesFromText( explode( "\n", $message->plain() ) );
 		}
 
 		return [];

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -8,7 +8,7 @@ use StringUtils;
 class CreateWikiRegexConstraint {
 	/**
 	 * @param string $regex invalid regex to log for
-	 * @param string $name name of regex caller (config or message) to log for
+	 * @param string $name name of regex caller (config or message key) to log for
 	 */
 	private static function logInvalidRegex( $regex, $name ) {
 		LoggerFactory::getInstance( 'CreateWiki' )->info(
@@ -22,7 +22,7 @@ class CreateWikiRegexConstraint {
 
 	/**
 	 * @param array &$regexes
-	 * @param string $name name of regex caller (config or message) for logging
+	 * @param string $name name of regex caller (config or message key) for logging
 	 * @param string $start
 	 * @param string $end
 	 * @return void
@@ -57,14 +57,16 @@ class CreateWikiRegexConstraint {
 
 	/**
 	 * @param string $text
-	 * @param string $name name of regex caller (config or message) for logging
+	 * @param string $start
+	 * @param string $end
+	 * @param string $name name of regex caller (config or message key) for logging
 	 * @return array
 	 */
-	private static function regexesFromText( $text, $name = '' ) {
+	private static function regexesFromText( $text, $start = '', $end = '', $name = '' ) {
 		$lines = explode( "\n", $text );
 		$regexes = self::cleanLines( $lines );
 
-		self::filterInvalidRegexes( $regexes, $name );
+		self::filterInvalidRegexes( $regexes, $name, $start, $end );
 
 		return $regexes;
 	}
@@ -73,7 +75,7 @@ class CreateWikiRegexConstraint {
 	 * @param array $regexes array of regexes to use for making into a string
 	 * @param string $start prepend to the beginning of the regex
 	 * @param string $end append to the end of the regex
-	 * @param string $name name of regex caller (config or message) for logging
+	 * @param string $name name of regex caller (config or message key) for logging
 	 * @return string
 	 */
 	public static function regexFromArray( $regexes, $start, $end, $name = '' ) {
@@ -123,13 +125,15 @@ class CreateWikiRegexConstraint {
 
 	/**
 	 * @param string $key
+	 * @param string $start prepend to the beginning of each regex line; used only for validation
+	 * @param string $end append to the end of each regex line; used only for validation
 	 * @return array
 	 */
-	public static function regexesFromMessage( $key ) {
+	public static function regexesFromMessage( $key, $start = '/', $end = '/i' ) {
 		$message = wfMessage( $key )->inContentLanguage();
 
 		if ( !$message->isDisabled() ) {
-			return self::regexesFromText( $message->plain(), "MediaWiki:{$key}" );
+			return self::regexesFromText( $message->plain(), $start, $end, "MediaWiki:{$key}" );
 		}
 
 		return [];

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Miraheze\CreateWiki;
+
+use StringUtils;
+
+class CreateWikiRegexConstraint {
+
+	/**
+	 * @param array $regexes
+	 * @return bool
+	 */
+	private static function validateRegexes( $regexes ) {
+		foreach ( $regexes as $regex ) {
+			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+	/**
+	 * @param array $lines
+	 * @return array
+	 */
+	private static function cleanLines( $lines ) {
+		return array_filter(
+			array_map( 'trim',
+				preg_replace( '/#.*$/', '', $lines )
+			)
+		);
+	}
+
+	/**
+	 * @param array $lines
+	 * @return array
+	 */
+	private static function regexesFromText( $lines ) {
+		$lines = self::cleanLines( $lines );
+		$regexes = explode( "\n", $lines );
+
+		if ( self::validateRegexes( $regexes ) ) {
+			return $regexes;
+		}
+
+		return [];
+	}
+
+	/**
+	 * @param string $key
+	 * @return array
+	 */
+	public static function regexesFromMessage( $key ) {
+		$message = wfMessage( $key )->inContentLanguage();
+
+		if ( !$message->isDisabled() ) {
+			return self::regexesFromText( $message->plain() );
+		}
+
+		return [];
+	}
+}

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -34,6 +34,8 @@ class CreateWikiRegexConstraint {
 	}
 
 	/**
+	 * Strip comments and whitespace, and remove blank lines
+	 *
 	 * @param array $lines
 	 * @return array
 	 */
@@ -61,9 +63,9 @@ class CreateWikiRegexConstraint {
 	}
 
 	/**
-	 * @param array $regexes
-	 * @param string $start
-	 * @param string $end
+	 * @param array $regexes array of regexes to use for making into a string
+	 * @param string $start prepend to the beginning of the regex
+	 * @param string $end append to the end of the regex
 	 * @return string
 	 */
 	public static function regexFromArray( $regexes, $start, $end ) {

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -114,7 +114,7 @@ class CreateWikiRegexConstraint {
 		$message = wfMessage( $key )->inContentLanguage();
 
 		if ( !$message->isDisabled() ) {
-			return self::regexesFromText( explode( "\n", $message->plain() ) );
+			return self::regexesFromText( $message->plain() );
 		}
 
 		return [];

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -11,7 +11,7 @@ class CreateWikiRegexConstraint {
 	 * @param string $name name of regex caller (config or message key) to log for
 	 */
 	private static function logInvalidRegex( $regex, $name ) {
-		LoggerFactory::getInstance( 'CreateWiki' )->warn(
+		LoggerFactory::getInstance( 'CreateWiki' )->warning(
 			'{name} contains invalid regex',
 			[
 				'name' => $name,

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -23,10 +23,12 @@ class CreateWikiRegexConstraint {
 	/**
 	 * @param array &$regexes
 	 * @param string $name name of regex caller (config or message) for logging
+	 * @param string $start
+	 * @param string $end
 	 */
-	private static function filterInvalidRegexes( &$regexes, $name = '' ) {
-		$regexes = array_filter( $regexes, static function ( $regex ) use ( $name ) {
-			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
+	private static function filterInvalidRegexes( &$regexes, $name = '', $start = '', $end = '' ) {
+		$regexes = array_filter( $regexes, static function ( $regex ) use ( $name, $start, $end ) {
+			if ( !StringUtils::isValidPCRERegex( $start . $regex . $end ) ) {
 				if ( $name ) {
 					self::logInvalidRegex( $regex, $name );
 				}
@@ -78,7 +80,7 @@ class CreateWikiRegexConstraint {
 			return '';
 		}
 
-		self::filterInvalidRegexes( $regexes, $name );
+		self::filterInvalidRegexes( $regexes, $name, $start, $end );
 
 		if ( !empty( $regexes ) ) {
 			$regex = $start . implode( '|', $regexes ) . $end;

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -87,6 +87,26 @@ class CreateWikiRegexConstraint {
 	}
 
 	/**
+	 * @param array|string $regex
+	 * @param string $start
+	 * @param string $end
+	 * @return string
+	 */
+	public static function regexFromArrayOrString( $regex, $start = '', $end = '' ) {
+		if ( is_array( $regex ) ) {
+			return self::regexFromArray( $regex, $start, $end );
+		} else {
+			if ( self::validateRegexes( [ $regex ] ) ) {
+				return $regex;
+			}
+		}
+
+		wfWarn( 'Contains invalid regex.' );
+
+		return '';
+	}
+
+	/**
 	 * @param string $key
 	 * @return array
 	 */

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -104,7 +104,7 @@ class CreateWikiRegexConstraint {
 	 * @param array|string $regex
 	 * @param string $start
 	 * @param string $end
-	 * @param string $name name of regex caller (config or message) for logging
+	 * @param string $name name of regex caller (config or message key) for logging
 	 * @return string
 	 */
 	public static function regexFromArrayOrString( $regex, $start = '', $end = '', $name = '' ) {

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -2,35 +2,40 @@
 
 namespace Miraheze\CreateWiki;
 
+use MediaWiki\Logger\LoggerFactory;
 use StringUtils;
 
 class CreateWikiRegexConstraint {
-
 	/**
-	 * @param array $regexes
-	 * @return bool
+	 * @param string $regex invalid regex to log for
+	 * @param string $name name of regex caller (config or message) to log for
 	 */
-	private static function validateRegexes( $regexes ) {
-		foreach ( $regexes as $regex ) {
-			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
-				return false;
-			}
-		}
-
-		return true;
+	private static function logInvalidRegex( $regex, $name ) {
+		LoggerFactory::getInstance( 'CreateWiki' )->info(
+			'{name} contains invalid regex',
+			[
+				'name' => $name,
+				'regex' => $regex,
+			]
+		);
 	}
 
 	/**
 	 * @param array &$regexes
+	 * @param string $name name of regex caller (config or message) for logging
 	 */
-	private static function filterInvalidRegexes( &$regexes ) {
-		foreach ( $regexes as $key => $regex ) {
+	private static function filterInvalidRegexes( &$regexes, $name = '' ) {
+		$regexes = array_filter( $regexes, static function ( $regex ) use ( $name ) {
 			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
-				wfWarn( 'Contains invalid regex.' );
+				if ( $name ) {
+					self::logInvalidRegex( $regex, $name );
+				}
 
-				unset( $regexes[$key] );
+				return false;
 			}
-		}
+
+			return true;
+		} );
 	}
 
 	/**
@@ -49,15 +54,14 @@ class CreateWikiRegexConstraint {
 
 	/**
 	 * @param string $text
+	 * @param string $name name of regex caller (config or message) for logging
 	 * @return array
 	 */
-	private static function regexesFromText( $text ) {
+	private static function regexesFromText( $text, $name = '' ) {
 		$lines = explode( "\n", $text );
 		$regexes = self::cleanLines( $lines );
 
-		if ( !self::validateRegexes( $regexes ) ) {
-			wfWarn( 'Contains invalid regex.' );
-		}
+		self::filterInvalidRegexes( $regexes, $name );
 
 		return $regexes;
 	}
@@ -66,24 +70,27 @@ class CreateWikiRegexConstraint {
 	 * @param array $regexes array of regexes to use for making into a string
 	 * @param string $start prepend to the beginning of the regex
 	 * @param string $end append to the end of the regex
+	 * @param string $name name of regex caller (config or message) for logging
 	 * @return string
 	 */
-	public static function regexFromArray( $regexes, $start, $end ) {
+	public static function regexFromArray( $regexes, $start, $end, $name = '' ) {
 		if ( empty( $regexes ) ) {
 			return '';
 		}
 
-		self::filterInvalidRegexes( $regexes );
+		self::filterInvalidRegexes( $regexes, $name );
 
 		if ( !empty( $regexes ) ) {
 			$regex = $start . implode( '|', $regexes ) . $end;
 
-			if ( self::validateRegexes( [ $regex ] ) ) {
+			if ( StringUtils::isValidPCRERegex( $regex ) ) {
 				return $regex;
 			}
-		}
 
-		wfWarn( 'Contains invalid regex.' );
+			if ( $name ) {
+				self::logInvalidRegex( $regex, $name );
+			}
+		}
 
 		return '';
 	}
@@ -92,17 +99,20 @@ class CreateWikiRegexConstraint {
 	 * @param array|string $regex
 	 * @param string $start
 	 * @param string $end
+	 * @param string $name name of regex caller (config or message) for logging
 	 * @return string
 	 */
-	public static function regexFromArrayOrString( $regex, $start = '', $end = '' ) {
+	public static function regexFromArrayOrString( $regex, $start = '', $end = '', $name = '' ) {
 		if ( is_array( $regex ) ) {
-			return self::regexFromArray( $regex, $start, $end );
+			return self::regexFromArray( $regex, $start, $end, $name );
 		} else {
-			if ( self::validateRegexes( [ $regex ] ) ) {
+			if ( StringUtils::isValidPCRERegex( $regex ) ) {
 				return $regex;
 			}
 
-			wfWarn( 'Contains invalid regex.' );
+			if ( $name ) {
+				self::logInvalidRegex( $regex, $name );
+			}
 		}
 
 		return '';
@@ -116,7 +126,7 @@ class CreateWikiRegexConstraint {
 		$message = wfMessage( $key )->inContentLanguage();
 
 		if ( !$message->isDisabled() ) {
-			return self::regexesFromText( $message->plain() );
+			return self::regexesFromText( $message->plain(), "MediaWiki:{$key}" );
 		}
 
 		return [];

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -24,11 +24,11 @@ class CreateWikiRegexConstraint {
 	 * @param array &$regexes
 	 */
 	private static function filterInvalidRegexes( &$regexes ) {
-		foreach ( $regexes as $regex ) {
+		foreach ( $regexes as $key => $regex ) {
 			if ( !StringUtils::isValidPCRERegex( $regex ) ) {
 				wfWarn( 'Contains invalid regex.' );
 
-				unset( $regexes[$regex] );
+				unset( $regexes[$key] );
 			}
 		}
 	}

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -25,6 +25,7 @@ class CreateWikiRegexConstraint {
 	 * @param string $name name of regex caller (config or message) for logging
 	 * @param string $start
 	 * @param string $end
+	 * @return void
 	 */
 	private static function filterInvalidRegexes( &$regexes, $name = '', $start = '', $end = '' ) {
 		$regexes = array_filter( $regexes, static function ( $regex ) use ( $name, $start, $end ) {

--- a/includes/CreateWikiRegexConstraint.php
+++ b/includes/CreateWikiRegexConstraint.php
@@ -19,6 +19,7 @@ class CreateWikiRegexConstraint {
 
 		return true;
 	}
+
 	/**
 	 * @param array $lines
 	 * @return array

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -43,7 +43,8 @@ class RequestWikiAIJob extends Job {
 
 	private function canAutoApprove( $config ) {
 		$descriptionFilter = CreateWikiRegexConstraint::regexFromArray(
-			$config->get( 'CreateWikiAutoApprovalFilter' ), '/(', ')+/'
+			$config->get( 'CreateWikiAutoApprovalFilter' ), '/(', ')+/',
+			'CreateWikiAutoApprovalFilter'
 		);
 
 		if ( preg_match( $descriptionFilter, strtolower( $this->params['description'] ) ) ) {

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -4,6 +4,7 @@ namespace Miraheze\CreateWiki\RequestWiki;
 
 use Job;
 use MediaWiki\MediaWikiServices;
+use Miraheze\CreateWiki\CreateWikiRegexConstraint;
 use Phpml\ModelManager;
 use Title;
 use User;
@@ -41,7 +42,10 @@ class RequestWikiAIJob extends Job {
 	}
 
 	private function canAutoApprove( $config ) {
-		$descriptionFilter = '/(' . implode( '|', $config->get( 'CreateWikiAutoApprovalFilter' ) ) . ')+/';
+		$descriptionFilter = CreateWikiRegexConstraint::regexFromArray(
+			'/(', $config->get( 'CreateWikiAutoApprovalFilter' ), ')+/'
+		);
+
 		if ( preg_match( $descriptionFilter, strtolower( $this->params['description'] ) ) ) {
 			return false;
 		}

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -43,7 +43,7 @@ class RequestWikiAIJob extends Job {
 
 	private function canAutoApprove( $config ) {
 		$descriptionFilter = CreateWikiRegexConstraint::regexFromArray(
-			'/(', $config->get( 'CreateWikiAutoApprovalFilter' ), ')+/'
+			$config->get( 'CreateWikiAutoApprovalFilter' ), '/(', ')+/'
 		);
 
 		if ( preg_match( $descriptionFilter, strtolower( $this->params['description'] ) ) ) {

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -7,10 +7,9 @@ use FormSpecialPage;
 use Html;
 use ManualLogEntry;
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Revision\RevisionRecord;
+use Miraheze\CreateWiki\CreateWikiRegexConstraint;
 use MWException;
 use SpecialPage;
-use TextContent;
 use Title;
 
 class SpecialRequestWiki extends FormSpecialPage {
@@ -171,12 +170,8 @@ class SpecialRequestWiki extends FormSpecialPage {
 	}
 
 	public function isValidReason( $reason, $allData ) {
-		$title = Title::newFromText( 'MediaWiki:CreateWiki-blacklist' );
-		$wikiPageContent = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title )->getContent( RevisionRecord::RAW );
-		$content = ( $wikiPageContent instanceof TextContent ) ? $wikiPageContent->getText() : '';
-
-		$regexes = explode( PHP_EOL, $content );
-		unset( $regexes[0] );
+		$regexes = CreateWikiRegexConstraint::regexesFromMessage( 'CreateWiki-disallowlist' ) ?:
+			CreateWikiRegexConstraint::regexesFromMessage( 'CreateWiki-blacklist' );
 
 		foreach ( $regexes as $regex ) {
 			preg_match( "/" . $regex . "/i", $reason, $output );

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -174,7 +174,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 			CreateWikiRegexConstraint::regexesFromMessage( 'CreateWiki-blacklist' );
 
 		foreach ( $regexes as $regex ) {
-			preg_match( "/" . $regex . "/i", $reason, $output );
+			preg_match( '/' . $regex . '/i', $reason, $output );
 
 			if ( is_array( $output ) && count( $output ) >= 1 ) {
 				return $this->msg( 'requestwiki-error-invalidcomment' )->escaped();

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -6,6 +6,7 @@ use ManualLogEntry;
 use MediaWiki\MediaWikiServices;
 use Message;
 use Miraheze\CreateWiki\CreateWiki\CreateWikiJob;
+use Miraheze\CreateWiki\CreateWikiRegexConstraint;
 use Miraheze\CreateWiki\WikiManager;
 use MWException;
 use SpecialPage;
@@ -341,11 +342,9 @@ class WikiRequest {
 	public function parseSubdomain( string $subdomain, string &$err = '' ) {
 		$subdomain = strtolower( $subdomain );
 
-		if ( is_array( $this->config->get( 'CreateWikiDisallowedSubdomains' ) ) ) {
-			$disallowedSubdomains = '/^(' . implode( '|', $this->config->get( 'CreateWikiDisallowedSubdomains' ) ) . ')+$/';
-		} else {
-			$disallowedSubdomains = $this->config->get( 'CreateWikiDisallowedSubdomains' );
-		}
+		$disallowedSubdomains = CreateWikiRegexConstraint::regexFromArrayOrString(
+			$this->config->get( 'CreateWikiDisallowedSubdomains' ), '/^(', ')+$/'
+		);
 
 		if ( strpos( $subdomain, $this->config->get( 'CreateWikiSubdomain' ) ) !== false ) {
 			$subdomain = str_replace( '.' . $this->config->get( 'CreateWikiSubdomain' ), '', $subdomain );

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -343,7 +343,8 @@ class WikiRequest {
 		$subdomain = strtolower( $subdomain );
 
 		$disallowedSubdomains = CreateWikiRegexConstraint::regexFromArrayOrString(
-			$this->config->get( 'CreateWikiDisallowedSubdomains' ), '/^(', ')+$/'
+			$this->config->get( 'CreateWikiDisallowedSubdomains' ), '/^(', ')+$/',
+			'CreateWikiDisallowedSubdomains'
 		);
 
 		if ( strpos( $subdomain, $this->config->get( 'CreateWikiSubdomain' ) ) !== false ) {


### PR DESCRIPTION
### Benefits: ###
* Add regex validation and sanitisation
* Avoid failing the entire regex if one line or array key is invalid, rather just skip it and log in debug log that something went wrong
* Improve on-wiki comment disallowed words message regex — don't pull from `Title::newFromText()`, but rather `wfMessage()` directly
* Centralised regex functions

Also deprecates `MediaWiki:CreateWiki-blacklist`, replacing it with `MediaWiki:CreateWiki-disallowlist`, temporally maintaining current as fallback to allow for time for transition.