### PR TITLE
Notifications: use primary link instead of secondary links

### DIFF
--- a/includes/Notifications/EchoCreateWikiPresentationModel.php
+++ b/includes/Notifications/EchoCreateWikiPresentationModel.php
@@ -24,16 +24,10 @@ class EchoCreateWikiPresentationModel extends EchoEventPresentationModel {
 	}
 
 	public function getPrimaryLink() {
-		return false;
-	}
-
-	public function getSecondaryLinks() {
-		$visitLink = [
+		return [
 			'url' => $this->event->getExtraParam( 'wiki-url', 0 ),
 			'label' => $this->msg( 'notification-createwiki-wiki-creation-visitwiki-label' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }

--- a/includes/Notifications/EchoRequestCommentPresentationModel.php
+++ b/includes/Notifications/EchoRequestCommentPresentationModel.php
@@ -23,16 +23,10 @@ class EchoRequestCommentPresentationModel extends EchoEventPresentationModel {
 	}
 
 	public function getPrimaryLink() {
-		return false;
-	}
-
-	public function getSecondaryLinks() {
-		$visitLink = [
+		return [
 			'url' => $this->event->getExtraParam( 'request-url', 0 ),
 			'label' => $this->msg( 'notification-createwiki-visit-request' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }

--- a/includes/Notifications/EchoRequestDeclinedPresentationModel.php
+++ b/includes/Notifications/EchoRequestDeclinedPresentationModel.php
@@ -23,16 +23,10 @@ class EchoRequestDeclinedPresentationModel extends EchoEventPresentationModel {
 	}
 
 	public function getPrimaryLink() {
-		return false;
-	}
-
-	public function getSecondaryLinks() {
-		$visitLink = [
+		return [
 			'url' => $this->event->getExtraParam( 'request-url', 0 ),
 			'label' => $this->msg( 'notification-createwiki-visit-request' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }


### PR DESCRIPTION
Per `PHP Notice: Trying to access array offset on value of type bool`:
https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EchoPlainTextEmailFormatter.php#L20, which is required, whereas https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EchoPlainTextEmailFormatter.php#L24 does the same thing with multiple, but is by default, an empty array (https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EventPresentationModel.php#L522), so does nothing.