### PR TITLE
Actually do update on changes being commited

### DIFF
--- a/includes/CreateWikiJson.php
+++ b/includes/CreateWikiJson.php
@@ -49,6 +49,8 @@ class CreateWikiJson {
 
 		// Rather than destroy object, let's fake the cache timestamp
 		$this->wikiTimestamp = $this->initTime;
+
+		$this->update();
 	}
 
 	public function resetDatabaseList() {
@@ -59,6 +61,8 @@ class CreateWikiJson {
 
 		// Rather than destroy object, let's fake the catch timestamp
 		$this->databaseTimestamp = $this->initTime;
+
+		$this->update();
 	}
 
 	public function update() {


### PR DESCRIPTION
Currently, commiting ManageWiki changes, or RemoteWiki::commit(), only invalidates timestamps, which then means it won't be updated until the next time the SetupAfterCache hook is ran (the next time the wiki being modified is accessed). This means that for example when updating the server in ManageWiki remotly, it actually is not properly updated until the next time the wiki with the now-changed server is accessed, so it is not done instantly causing initial issues with cache, etc....