### PR TITLE
Add hooks for reading and writing persistent model

### DIFF
--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -9,12 +9,14 @@ class CreateWikiHookRunner implements
 	CreateWikiDeletionHook,
 	CreateWikiJsonBuilderHook,
 	CreateWikiJsonGenerateDatabaseListHook,
+	CreateWikiReadPersistentModelHook,
 	CreateWikiRenameHook,
 	CreateWikiStateClosedHook,
 	CreateWikiStateOpenHook,
 	CreateWikiStatePrivateHook,
 	CreateWikiStatePublicHook,
-	CreateWikiTablesHook
+	CreateWikiTablesHook,
+	CreateWikiWritePersistentModelHook
 {
 	/**
 	 * @var HookContainer
@@ -57,6 +59,14 @@ class CreateWikiHookRunner implements
 		$this->container->run(
 			'CreateWikiJsonGenerateDatabaseList',
 			[ &$databaseLists ]
+		);
+	}
+
+	/** @inheritDoc */
+	public function onCreateWikiReadPersistentModel( &$pipeline ): void {
+		$this->container->run(
+			'CreateWikiReadPersistentModel',
+			[ &$pipeline ]
 		);
 	}
 
@@ -105,6 +115,14 @@ class CreateWikiHookRunner implements
 		$this->container->run(
 			'CreateWikiTables',
 			[ &$cTables ]
+		);
+	}
+
+	/** @inheritDoc */
+	public function onCreateWikiWritePersistentModel( $pipeline ): bool {
+		return $this->container->run(
+			'CreateWikiWritePersistentModel',
+			[ $pipeline ]
 		);
 	}
 }

--- a/includes/Hooks/CreateWikiReadPersistentModelHook.php
+++ b/includes/Hooks/CreateWikiReadPersistentModelHook.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Miraheze\CreateWiki\Hooks;
+
+interface CreateWikiReadPersistentModelHook {
+	/**
+	 * @param string &$pipeline
+	 * @return void
+	 */
+	public function onCreateWikiReadPersistentModel( &$pipeline ): void;
+}

--- a/includes/Hooks/CreateWikiWritePersistentModelHook.php
+++ b/includes/Hooks/CreateWikiWritePersistentModelHook.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Miraheze\CreateWiki\Hooks;
+
+interface CreateWikiWritePersistentModelHook {
+	/**
+	 * @param string $pipeline
+	 * @return bool
+	 */
+	public function onCreateWikiWritePersistentModel( $pipeline ): bool;
+}

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -24,6 +24,7 @@ class RequestWikiAIJob extends Job {
 		$pipeline = '';
 		$hookRunner->onCreateWikiReadPersistentModel( $pipeline );
 
+		// @phan-suppress-next-line PhanImpossibleCondition
 		if ( $pipeline || ( $modelFile && file_exists( $modelFile ) ) ) {
 			if ( !$pipeline ) {
 				$modelManager = new ModelManager();

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -22,7 +22,7 @@ class RequestWikiAIJob extends Job {
 		$wr = new WikiRequest( $this->params['id'], $hookRunner );
 
 		$pipeline = '';
-		$hookRunner->onCreateWikiReadPersistentModel( &$pipeline );
+		$hookRunner->onCreateWikiReadPersistentModel( $pipeline );
 
 		if ( $pipeline || ( $modelFile && file_exists( $modelFile ) ) ) {
 			if ( !$pipeline ) {

--- a/includes/RequestWiki/RequestWikiAIJob.php
+++ b/includes/RequestWiki/RequestWikiAIJob.php
@@ -21,9 +21,15 @@ class RequestWikiAIJob extends Job {
 
 		$wr = new WikiRequest( $this->params['id'], $hookRunner );
 
-		if ( file_exists( $modelFile ) ) {
-			$modelManager = new ModelManager();
-			$pipeline = $modelManager->restoreFromFile( $modelFile );
+		$pipeline = '';
+		$hookRunner->onCreateWikiReadPersistentModel( &$pipeline );
+
+		if ( $pipeline || ( $modelFile && file_exists( $modelFile ) ) ) {
+			if ( !$pipeline ) {
+				$modelManager = new ModelManager();
+				$pipeline = $modelManager->restoreFromFile( $modelFile );
+			}
+
 			$tokenDescription = (array)strtolower( $this->params['description'] );
 
 			// @phan-suppress-next-line PhanUndeclaredMethod

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -336,12 +336,6 @@ class WikiRequest {
 	}
 
 	public function tryAutoCreate() {
-		$modelFile = $this->config->get( 'CreateWikiPersistentModelFile' );
-
-		if ( !$modelFile ) {
-			return;
-		}
-
 		$jobQueueGroup = MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup();
 		$jobQueueGroup->push( new RequestWikiAIJob(
 			Title::newMainPage(),

--- a/maintenance/createPersistentModel.php
+++ b/maintenance/createPersistentModel.php
@@ -82,8 +82,11 @@ class CreatePersistentModel extends Maintenance {
 
 		$pipeline->train( $comments, $status );
 
-		$modelManager = new ModelManager();
-		$modelManager->saveToFile( $pipeline, $config->get( 'CreateWikiPersistentModelFile' ) );
+		$hookRunner = MediaWikiServices::getInstance()->get( 'CreateWikiHookRunner' );
+		if ( !$hookRunner->onCreateWikiWritePersistentModel( serialize( $pipeline ) ) ) {
+			$modelManager = new ModelManager();
+			$modelManager->saveToFile( $pipeline, $config->get( 'CreateWikiPersistentModelFile' ) );
+		}
 	}
 }
 


### PR DESCRIPTION
We can potentially use something similar to this for compatibility with Swift:
```php
use MediaWiki\MediaWikiServices;

public static function onCreateWikiReadPersistentModel( &$pipeline ) {
	$backend = MediaWikiServices::getInstance()->getFileBackendGroup()->get( 'swift-backend' );

	if ( $backend->fileExists( [ 'src' => $backend->getContainerStoragePath( 'createwiki-persistent-model' ) . '/requestmodel.phpml' ] ) ) {
		$pipeline = unserialize(
			$backend->getFileContents( [
				'src' => $backend->getContainerStoragePath( 'createwiki-persistent-model' ) . '/requestmodel.phpml',
			] )
		);
	}
}

public static function onCreateWikiWritePersistentModel( $pipeline ) {
	$backend = MediaWikiServices::getInstance()->getFileBackendGroup()->get( 'swift-backend' );
	$backend->prepare( [ 'dir' => $backend->getContainerStoragePath( 'createwiki-persistent-model' ) ] );

	$backend->quickCreate( [
		'dst' => $backend->getContainerStoragePath( 'createwiki-persistent-model' ) . '/requestmodel.phpml',
		'content' => $pipeline,
		'overwrite' => true,
	] );

	return true;
}
```