### PR TITLE
Make sure local zones are created and secure when necessary

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -273,7 +273,7 @@
 			"value": false
 		},
 		"CreateWikiUseSecureContainers": {
-			"description": "Boolean. Whether to use secure containers for file backend. If enabled, deleted and temp containers are always secure, and all contaners are secure for private wikis.",
+			"description": "Boolean. Whether to use secure containers for file backend. If enabled, deleted and temp containers are always secure, and all default (core) local contaners are secure for private wikis. Additional containers can be secured with $wgCreateWikiExtraSecuredContainers.",
 			"public": true,
 			"value": false
 		},

--- a/extension.json
+++ b/extension.json
@@ -272,6 +272,11 @@
 			"public": true,
 			"value": false
 		},
+		"CreateWikiUseSecureContainers": {
+			"description": "Boolean. Whether to use secure containers for file backend. If enabled, deleted and temp containers are always secure, and all contaners are secure for private wikis.",
+			"public": true,
+			"value": false
+		},
 		"CreateWikiCollation": {
 			"description": "String. Sets the collation to use when creating the wiki database. Example is 'DEFAULT SET utf8mb4 COLLATE utf8mb4_unicode_ci'",
 			"public": true,

--- a/extension.json
+++ b/extension.json
@@ -277,6 +277,11 @@
 			"public": true,
 			"value": false
 		},
+		"CreateWikiExtraContainers": {
+			"description": "Array. List of extra containers to ensure creation on and to secure if $wgCreateWikiUseSecureContainers is enabled.",
+			"public": true,
+			"value": []
+		},
 		"CreateWikiCollation": {
 			"description": "String. Sets the collation to use when creating the wiki database. Example is 'DEFAULT SET utf8mb4 COLLATE utf8mb4_unicode_ci'",
 			"public": true,

--- a/extension.json
+++ b/extension.json
@@ -277,11 +277,6 @@
 			"public": true,
 			"value": false
 		},
-		"CreateWikiExtraContainers": {
-			"description": "Array. List of extra containers to ensure creation on and to secure if $wgCreateWikiUseSecureContainers is enabled.",
-			"public": true,
-			"value": []
-		},
 		"CreateWikiCollation": {
 			"description": "String. Sets the collation to use when creating the wiki database. Example is 'DEFAULT SET utf8mb4 COLLATE utf8mb4_unicode_ci'",
 			"public": true,

--- a/extension.json
+++ b/extension.json
@@ -277,6 +277,11 @@
 			"public": true,
 			"value": false
 		},
+		"CreateWikiExtraSecuredContainers": {
+			"description": "Array. List of extra local containers to secure for private wikis if $wgCreateWikiUseSecureContainers is enabled.",
+			"public": true,
+			"value": []
+		},
 		"CreateWikiCollation": {
 			"description": "String. Sets the collation to use when creating the wiki database. Example is 'DEFAULT SET utf8mb4 COLLATE utf8mb4_unicode_ci'",
 			"public": true,

--- a/includes/RemoteWiki.php
+++ b/includes/RemoteWiki.php
@@ -200,7 +200,7 @@ class RemoteWiki {
 
 			if ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) ) {
 				foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
-					$dir = $repo->getContainerStoragePath( $container );
+					$dir = $backend->getContainerStoragePath( $container );
 					$backend->prepare( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 					$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 				}
@@ -229,7 +229,7 @@ class RemoteWiki {
 
 			if ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) ) {
 				foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
-					$dir = $repo->getContainerStoragePath( $container );
+					$dir = $backend->getContainerStoragePath( $container );
 					$backend->publish( [ 'dir' => $dir, 'access' => true ] );
 				}
 			}

--- a/includes/RemoteWiki.php
+++ b/includes/RemoteWiki.php
@@ -189,6 +189,21 @@ class RemoteWiki {
 			'new' => 1
 		];
 
+		if ( $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
+			// Make sure all of the file repo zones are secured
+			$repo = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
+			$backend = $repo->getBackend();
+			foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
+				$dir = $repo->getZonePath( $zone );
+
+				$backend->secure( [
+					'dir' => $dir,
+					'noAccess' => true,
+					'noListing' => true,
+				] );
+			}
+		}
+
 		$this->hooks[] = 'CreateWikiStatePrivate';
 		$this->private = true;
 		$this->newRows['wiki_private'] = true;
@@ -199,6 +214,20 @@ class RemoteWiki {
 			'old' => 0,
 			'new' => 1
 		];
+
+		if ( $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
+			// Make sure all of the file repo zones are marked public except for the deleted and temp zones
+			$repo = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
+			$backend = $repo->getBackend();
+			foreach ( [ 'public', 'thumb', 'transcoded' ] as $zone ) {
+				$dir = $repo->getZonePath( $zone );
+
+				$backend->publish( [
+					'dir' => $dir,
+					'access' => true,
+				] );
+			}
+		}
 
 		$this->hooks[] = 'CreateWikiStatePublic';
 		$this->private = false;

--- a/includes/RemoteWiki.php
+++ b/includes/RemoteWiki.php
@@ -195,12 +195,15 @@ class RemoteWiki {
 			$backend = $repo->getBackend();
 			foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
 				$dir = $repo->getZonePath( $zone );
+				$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
+			}
 
-				$backend->secure( [
-					'dir' => $dir,
-					'noAccess' => true,
-					'noListing' => true,
-				] );
+			if ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) ) {
+				foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
+					$dir = $repo->getContainerStoragePath( $container );
+					$backend->prepare( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
+					$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
+				}
 			}
 		}
 
@@ -221,11 +224,14 @@ class RemoteWiki {
 			$backend = $repo->getBackend();
 			foreach ( [ 'public', 'thumb', 'transcoded' ] as $zone ) {
 				$dir = $repo->getZonePath( $zone );
+				$backend->publish( [ 'dir' => $dir, 'access' => true ] );
+			}
 
-				$backend->publish( [
-					'dir' => $dir,
-					'access' => true,
-				] );
+			if ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) ) {
+				foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
+					$dir = $repo->getContainerStoragePath( $container );
+					$backend->publish( [ 'dir' => $dir, 'access' => true ] );
+				}
 			}
 		}
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -163,7 +163,7 @@ class WikiManager {
 			$this->config->get( 'CreateWikiExtraSecuredContainers' )
 		) {
 			foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
-				$dir = $repo->getContainerStoragePath( $container );
+				$dir = $backend->getContainerStoragePath( $container );
 				$backend->prepare( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 				$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 			}

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -143,9 +143,9 @@ class WikiManager {
 		$backend = $repo->getBackend();
 		foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
 			$dir = $repo->getZonePath( $zone );
-			$secure = ( $zone === 'deleted' || $zone === 'temp' || $private )
-				? [ 'noAccess' => true, 'noListing' => true ]
-				: [];
+			$secure = ( $this->config->get( 'CreateWikiUseSecureContainers' ) &&
+					( $zone === 'deleted' || $zone === 'temp' || $private )
+				) ? [ 'noAccess' => true, 'noListing' => true ] : [];
 
 			$backend->prepare( [ 'dir' => $dir ] + $secure );
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -141,7 +141,7 @@ class WikiManager {
 		// Make sure all of the file repo zones are setup
 		$repo = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
 		$backend = $repo->getBackend();
-		foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
+		foreach ( [ 'public', 'thumbs', 'transcoded', 'temp', 'deleted' ] as $zone ) {
 			$dir = $repo->getZonePath( $zone );
 			$secure = ( $this->config->get( 'CreateWikiUseSecureContainers' ) &&
 				( $zone === 'deleted' || $zone === 'temp' || $private )

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -157,10 +157,13 @@ class WikiManager {
 			$backend->publish( [ 'dir' => $dir, 'access' => true ] );
 		}
 
-		if ( $private && $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
-			foreach ( $this->config->get( 'CreateWikiExtraContainers' ) as $container ) {
+		if (
+			$private &&
+			$this->config->get( 'CreateWikiUseSecureContainers' ) &&
+			$this->config->get( 'CreateWikiExtraSecuredContainers' )
+		) {
+			foreach ( $this->config->get( 'CreateWikiExtraSecuredContainers' ) as $container ) {
 				$dir = $repo->getContainerStoragePath( $container );
-
 				$backend->prepare( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 				$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
 			}

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -157,6 +157,15 @@ class WikiManager {
 			$backend->publish( [ 'dir' => $dir, 'access' => true ] );
 		}
 
+		if ( $private && $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
+			foreach ( $this->config->get( 'CreateWikiExtraContainers' ) as $container ) {
+				$dir = $repo->getContainerStoragePath( $container );
+
+				$backend->prepare( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
+				$backend->secure( [ 'dir' => $dir, 'noAccess' => true, 'noListing' => true ] );
+			}
+		}
+
 		$blankConfig = new GlobalVarConfig( '' );
 
 		Shell::makeScriptCommand(

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -141,7 +141,7 @@ class WikiManager {
 		// Make sure all of the file repo zones are setup
 		$repo = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo();
 		$backend = $repo->getBackend();
-		foreach ( [ 'public', 'thumbs', 'transcoded', 'temp', 'deleted' ] as $zone ) {
+		foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
 			$dir = $repo->getZonePath( $zone );
 			$secure = ( $this->config->get( 'CreateWikiUseSecureContainers' ) &&
 				( $zone === 'deleted' || $zone === 'temp' || $private )

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -144,8 +144,8 @@ class WikiManager {
 		foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
 			$dir = $repo->getZonePath( $zone );
 			$secure = ( $this->config->get( 'CreateWikiUseSecureContainers' ) &&
-					( $zone === 'deleted' || $zone === 'temp' || $private )
-				) ? [ 'noAccess' => true, 'noListing' => true ] : [];
+				( $zone === 'deleted' || $zone === 'temp' || $private )
+			) ? [ 'noAccess' => true, 'noListing' => true ] : [];
 
 			$backend->prepare( [ 'dir' => $dir ] + $secure );
 

--- a/tests/phpunit/RemoteWikiTest.php
+++ b/tests/phpunit/RemoteWikiTest.php
@@ -22,9 +22,9 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 
 		$conf = new SiteConfiguration();
 		$conf->suffixes = [ 'test' ];
-		$this->setMwGlobals( [
-			'wgConf' => $conf,
-		] );
+
+		$this->setMwGlobals( 'wgConf', $conf );
+		$this->setMwGlobals( 'wgCreateWikiUseSecureContainers', true );
 
 		$db = Database::factory( 'mysql', [ 'host' => $GLOBALS['wgDBserver'], 'user' => 'root' ] );
 

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -202,6 +202,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 
 	/**
 	 * @param string $dbname
+	 * @param bool $private
 	 * @return mixed
 	 */
 	private function createWiki( string $dbname, bool $private = false ) {

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -3,6 +3,7 @@
 namespace Miraheze\CreateWiki\Tests;
 
 use FatalError;
+use LocalRepo;
 use MediaWikiIntegrationTestCase;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
@@ -59,6 +60,12 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	public function testCreatePrivate() {
 		$this->assertNull( $this->createWiki( 'createwikiprivatetest', true ) );
 		$this->assertTrue( $this->wikiExists( 'createwikiprivatetest' ) );
+	}
+
+	public function testLocalZoneCreated() {
+		$repo = $this->createMock( LocalRepo::class );
+		$zonePath = $repo->getZonePath( 'public' );
+		$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) )
 	}
 
 	/**

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -71,8 +71,10 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 			'backend' => 'local-backend',
 		] );
 
-		$zonePath = $repo->getZonePath( 'public' );
-		$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) );
+		foreach ( [ 'public', 'thumb', 'transcoded', 'temp', 'deleted' ] as $zone ) {
+			$zonePath = $repo->getZonePath( $zone );
+			$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) );
+		}
 	}
 
 	/**

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -65,7 +65,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	public function testLocalZoneCreated() {
 		$repo = $this->createMock( LocalRepo::class );
 		$zonePath = $repo->getZonePath( 'public' );
-		$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) )
+		$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) );
 	}
 
 	/**

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -63,7 +63,11 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	}
 
 	public function testLocalZoneCreated() {
-		$repo = $this->createMock( LocalRepo::class );
+		$repo = new LocalRepo( [
+			'name' => 'local',
+			'backend' => 'local-backend',
+		] );
+
 		$zonePath = $repo->getZonePath( 'public' );
 		$this->assertTrue( $repo->getBackend()->directoryExists( [ 'dir' => $zonePath ] ) );
 	}

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -62,6 +62,9 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$this->assertTrue( $this->wikiExists( 'createwikiprivatetest' ) );
 	}
 
+	/**
+	 * @covers ::create
+	 */
 	public function testLocalZoneCreated() {
 		$repo = new LocalRepo( [
 			'name' => 'local',

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -22,14 +22,15 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 
 		$conf = new SiteConfiguration();
 		$conf->suffixes = [ 'test' ];
-		$this->setMwGlobals( [
-			'wgConf' => $conf,
-		] );
+
+		$this->setMwGlobals( 'wgConf', $conf );
+		$this->setMwGlobals( 'wgCreateWikiUseSecureContainers', true );
 
 		$db = Database::factory( 'mysql', [ 'host' => $GLOBALS['wgDBserver'], 'user' => 'root' ] );
 
 		$db->begin();
 		$db->query( "GRANT ALL PRIVILEGES ON `createwikitest`.* TO 'wikiuser'@'localhost';" );
+		$db->query( "GRANT ALL PRIVILEGES ON `createwikiprivatetest`.* TO 'wikiuser'@'localhost';" );
 		$db->query( "GRANT ALL PRIVILEGES ON `deletewikitest`.* TO 'wikiuser'@'localhost';" );
 		$db->query( "GRANT ALL PRIVILEGES ON `recreatewikitest`.* TO 'wikiuser'@'localhost';" );
 		$db->query( "GRANT ALL PRIVILEGES ON `renamewikitest`.* TO 'wikiuser'@'localhost';" );
@@ -50,6 +51,14 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	public function testCreateSuccess() {
 		$this->assertNull( $this->createWiki( 'createwikitest' ) );
 		$this->assertTrue( $this->wikiExists( 'createwikitest' ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function testCreatePrivate() {
+		$this->assertNull( $this->createWiki( 'createwikiprivatetest', true ) );
+		$this->assertTrue( $this->wikiExists( 'createwikiprivatetest' ) );
 	}
 
 	/**
@@ -195,13 +204,13 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	 * @param string $dbname
 	 * @return mixed
 	 */
-	private function createWiki( string $dbname ) {
+	private function createWiki( string $dbname, bool $private = false ) {
 		$testUser = $this->getTestUser()->getUser();
 		$testSysop = $this->getTestSysop()->getUser();
 
 		$wikiManager = new WikiManager( $dbname, $this->getMockCreateWikiHookRunner() );
 
-		return $wikiManager->create( 'TestWiki', 'en', 0, 'uncategorised', $testUser->getName(), $testSysop->getName(), 'Test' );
+		return $wikiManager->create( 'TestWiki', 'en', $private, 'uncategorised', $testUser->getName(), $testSysop->getName(), 'Test' );
 	}
 
 	/**

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -65,7 +65,7 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::create
 	 */
-	public function testLocalZoneCreated() {
+	public function testLocalZonesCreated() {
 		$repo = new LocalRepo( [
 			'name' => 'local',
 			'backend' => 'local-backend',


### PR DESCRIPTION
Doing here rather than using the hooks, as in this instance, may not be Miraheze-specific and should always ensure that/

Also adds `$wgCreateWikiUseSecureContainers` and `$wgCreateWikiExtraSecuredContainers` configs.