### PR TITLE
Display read-only errors when database is in read-only

### DIFF
--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -26,6 +26,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 	protected function getFormFields() {
 		$par = $this->par;
 		$request = $this->getRequest();
+		$this->checkReadOnly();
 
 		$formDescriptor = [
 			'dbname' => [

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -33,9 +33,9 @@ class SpecialRequestWiki extends FormSpecialPage {
 		$this->requireLogin( 'requestwiki-notloggedin' );
 		$this->setParameter( $par );
 		$this->setHeaders();
-		$this->checkReadOnly();
 
 		$this->checkExecutePermissions( $this->getUser() );
+		$this->checkReadOnly();
 
 		if ( !$request->wasPosted() && $this->config->get( 'CreateWikiCustomDomainPage' ) ) {
 			$customdomainurl = Title::newFromText( $this->config->get( 'CreateWikiCustomDomainPage' ) )->getFullURL();

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -29,6 +29,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 	public function execute( $par ) {
 		$request = $this->getRequest();
 		$out = $this->getOutput();
+		$this->checkReadOnly();
 
 		$this->requireLogin( 'requestwiki-notloggedin' );
 		$this->setParameter( $par );

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -34,8 +34,8 @@ class SpecialRequestWiki extends FormSpecialPage {
 		$this->setParameter( $par );
 		$this->setHeaders();
 
-		$this->checkExecutePermissions( $this->getUser() );
 		$this->checkReadOnly();
+		$this->checkExecutePermissions( $this->getUser() );
 
 		if ( !$request->wasPosted() && $this->config->get( 'CreateWikiCustomDomainPage' ) ) {
 			$customdomainurl = Title::newFromText( $this->config->get( 'CreateWikiCustomDomainPage' ) )->getFullURL();

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -29,11 +29,11 @@ class SpecialRequestWiki extends FormSpecialPage {
 	public function execute( $par ) {
 		$request = $this->getRequest();
 		$out = $this->getOutput();
-		$this->checkReadOnly();
 
 		$this->requireLogin( 'requestwiki-notloggedin' );
 		$this->setParameter( $par );
 		$this->setHeaders();
+		$this->checkReadOnly();
 
 		$this->checkExecutePermissions( $this->getUser() );
 


### PR DESCRIPTION
When the database is in read-only mode, all forms are still usable. Some of them will throw a "DBReadOnlyError" once you click submit which is counterintuitive as a user might think they're fine to request a wiki/do an action but then will receive an error once they submit a form. Now, they'll see a read-only error which will prevent them from doing any action