### PR TITLE
Revert "Replace deprecated `wfGetDB()`"

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -16,6 +16,7 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 
 $cfg['suppress_issue_types'] = [
 	'PhanAccessMethodInternal',
+	'PhanDeprecatedFunction',
 	'SecurityCheck-LikelyFalsePositive',
 ];
 

--- a/includes/CreateWikiJson.php
+++ b/includes/CreateWikiJson.php
@@ -47,10 +47,7 @@ class CreateWikiJson {
 	}
 
 	public function resetWiki() {
-		$this->dbr ??= MediaWikiServices::getInstance()->getDBLoadBalancerFactory()
-			->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-			->getMaintenanceConnectionRef( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-
+		$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 		$this->initTime ??= $this->dbr->timestamp();
 
 		$this->cache->set( $this->cache->makeGlobalKey( 'CreateWiki', $this->wiki ), $this->initTime );
@@ -60,10 +57,7 @@ class CreateWikiJson {
 	}
 
 	public function resetDatabaseList() {
-		$this->dbr ??= MediaWikiServices::getInstance()->getDBLoadBalancerFactory()
-			->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-			->getMaintenanceConnectionRef( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
-
+		$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 		$this->initTime ??= $this->dbr->timestamp();
 
 		$this->cache->set( $this->cache->makeGlobalKey( 'CreateWiki', 'databases' ), $this->initTime );
@@ -76,17 +70,13 @@ class CreateWikiJson {
 		$changes = $this->newChanges();
 
 		if ( $changes['databases'] ) {
-			$this->dbr ??= MediaWikiServices::getInstance()->getDBLoadBalancerFactory()
-				->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-				->getMaintenanceConnectionRef( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
+			$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 
 			$this->generateDatabaseList();
 		}
 
 		if ( $changes['wiki'] ) {
-			$this->dbr ??= MediaWikiServices::getInstance()->getDBLoadBalancerFactory()
-				->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-				->getMaintenanceConnectionRef( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
+			$this->dbr ??= wfGetDB( DB_REPLICA, [], $this->config->get( 'CreateWikiDatabase' ) );
 
 			$this->generateWiki();
 		}

--- a/includes/RemoteWiki.php
+++ b/includes/RemoteWiki.php
@@ -36,10 +36,7 @@ class RemoteWiki {
 		$this->config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'CreateWiki' );
 		$this->hookRunner = $hookRunner ?? MediaWikiServices::getInstance()->get( 'CreateWikiHookRunner' );
 
-		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
-		$this->dbw = $lbFactory->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-			->getMaintenanceConnectionRef( DB_PRIMARY, [], $this->config->get( 'CreateWikiDatabase' ) );
-
+		$this->dbw = wfGetDB( DB_PRIMARY, [], $this->config->get( 'CreateWikiDatabase' ) );
 		$wikiRow = $this->dbw->selectRow(
 			'cw_wikis',
 			'*',

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -40,10 +40,7 @@ class WikiRequest {
 	public function __construct( int $id = null, CreateWikiHookRunner $hookRunner = null ) {
 		$this->config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'CreateWiki' );
 		$this->hookRunner = $hookRunner ?? MediaWikiServices::getInstance()->get( 'CreateWikiHookRunner' );
-
-		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
-		$this->dbw = $lbFactory->getMainLB( $this->config->get( 'CreateWikiGlobalWiki' ) )
-			->getMaintenanceConnectionRef( DB_PRIMARY, [], $this->config->get( 'CreateWikiGlobalWiki' ) );
+		$this->dbw = wfGetDB( DB_PRIMARY, [], $this->config->get( 'CreateWikiGlobalWiki' ) );
 
 		$userFactory = MediaWikiServices::getInstance()->getUserFactory();
 

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -13,7 +13,6 @@ use Title;
 
 class WikiManager {
 	private $config;
-	private $lbFactory;
 	private $cluster;
 	private $dbname;
 	private $dbw;
@@ -28,10 +27,7 @@ class WikiManager {
 	public function __construct( string $dbname, CreateWikiHookRunner $hookRunner = null ) {
 		$this->config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'CreateWiki' );
 		$this->hookRunner = $hookRunner ?? MediaWikiServices::getInstance()->get( 'CreateWikiHookRunner' );
-		$this->lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
-
-		$this->cwdb = $this->lbFactory->getMainLB( $this->config->get( 'CreateWikiDatabase' ) )
-			->getMaintenanceConnectionRef( DB_PRIMARY, [], $this->config->get( 'CreateWikiDatabase' ) );
+		$this->cwdb = wfGetDB( DB_PRIMARY, [], $this->config->get( 'CreateWikiDatabase' ) );
 
 		$check = $this->cwdb->selectRow(
 			'cw_wikis',
@@ -77,8 +73,7 @@ class WikiManager {
 			$newDbw = $this->cwdb;
 		} else {
 			// DB exists
-			$newDbw = $this->lbFactory->getMainLB( $dbname )
-				->getMaintenanceConnectionRef( DB_PRIMARY, [], $dbname );
+			$newDbw = wfGetDB( DB_PRIMARY, [], $dbname );
 		}
 
 		$this->dbname = $dbname;
@@ -118,8 +113,7 @@ class WikiManager {
 		if ( $this->lb ) {
 			$this->dbw = $this->lb->getConnection( DB_PRIMARY, [], $wiki );
 		} else {
-			$this->dbw = $this->lbFactory->getMainLB( $wiki )
-				->getMaintenanceConnectionRef( DB_PRIMARY, [], $wiki );
+			$this->dbw = wfGetDB( DB_PRIMARY, [], $wiki );
 		}
 
 		$this->cwdb->insert(
@@ -323,8 +317,7 @@ class WikiManager {
 			return;
 		}
 
-		$logDBConn = $this->lbFactory->getMainLB( $loggingWiki ?? $this->config->get( 'CreateWikiGlobalWiki' ) )
-			->getMaintenanceConnectionRef( DB_PRIMARY, [], $loggingWiki ?? $this->config->get( 'CreateWikiGlobalWiki' ) );
+		$logDBConn = wfGetDB( DB_PRIMARY, [], $loggingWiki ?? $this->config->get( 'CreateWikiGlobalWiki' ) );
 
 		$logEntry = new ManualLogEntry( $log, $action );
 		$logEntry->setPerformer( $user );


### PR DESCRIPTION
Reverts miraheze/CreateWiki#356

If this isn't an injected load balancer, then wfGetDB() is necessary. Otherwise it causes a drift, leading to errors with wiki creations.