### PR TITLE
delay recacheJson to DeferredUpdates

### DIFF
--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -136,8 +136,6 @@ class WikiManager {
 			]
 		);
 
-		$this->recacheJson();
-
 		foreach ( $this->config->get( 'CreateWikiSQLfiles' ) as $sqlfile ) {
 			$this->dbw->sourceFile( $sqlfile );
 		}
@@ -146,6 +144,8 @@ class WikiManager {
 
 		DeferredUpdates::addCallableUpdate(
 			static function () use ( $wiki, $requester ) {
+				$this->recacheJson();
+				
 				Shell::makeScriptCommand(
 					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/setContainersAccess.php',
 					[

--- a/includes/WikiManager.php
+++ b/includes/WikiManager.php
@@ -143,9 +143,9 @@ class WikiManager {
 		$this->hookRunner->onCreateWikiCreation( $wiki, $private );
 
 		DeferredUpdates::addCallableUpdate(
-			static function () use ( $wiki, $requester ) {
+			function () use ( $wiki, $requester ) {
 				$this->recacheJson();
-				
+
 				Shell::makeScriptCommand(
 					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/setContainersAccess.php',
 					[


### PR DESCRIPTION
this will ensure that even if another process triggers CreateWikiJson::update at the same time (causing a race condition to updating the databases.json list), the changes to cw_wikis will be committed and available to all processes that might be affected by this race condition.