### PR TITLE
Add link from wiki request back to queue

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,7 +98,6 @@
 	"requestwikiqueue-request-label-visibility-delete": "Everyone with 'delete' permissions can view this request",
 	"requestwikiqueue-request-label-visibility-hide": "Everyone with 'createwiki' permissions can view this request",
 	"requestwikiqueue-request-label-visibility-oversight": "Everyone with 'suppressrevision' permissions can view this request",
-	"requestwikiqueue-request-view": "View a wiki request",
 	"right-requestwiki": "Request wikis",
 	"right-createwiki": "Create wikis"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,6 +98,7 @@
 	"requestwikiqueue-request-label-visibility-delete": "Everyone with 'delete' permissions can view this request",
 	"requestwikiqueue-request-label-visibility-hide": "Everyone with 'createwiki' permissions can view this request",
 	"requestwikiqueue-request-label-visibility-oversight": "Everyone with 'suppressrevision' permissions can view this request",
+	"requestwikiqueue-request-view": "View a wiki request",
 	"right-requestwiki": "Request wikis",
 	"right-createwiki": "Create wikis"
 }

--- a/includes/RequestWiki/SpecialRequestWikiQueue.php
+++ b/includes/RequestWiki/SpecialRequestWikiQueue.php
@@ -25,7 +25,7 @@ class SpecialRequestWikiQueue extends SpecialPage {
 		} else {
 			$this->lookupRequest( $par );
 
-			$this->getOutput()->setPageTitle( $this->msg( 'createwiki-viewrequest' )->text() );
+			$this->getOutput()->setPageTitle( $this->msg( 'requestwikiqueue-request-view' )->text() );
 
 			$link = $this->getLinkRenderer()->makeKnownLink(
 				static::getSafeTitleFor( 'RequestWikiQueue' ),

--- a/includes/RequestWiki/SpecialRequestWikiQueue.php
+++ b/includes/RequestWiki/SpecialRequestWikiQueue.php
@@ -24,6 +24,14 @@ class SpecialRequestWikiQueue extends SpecialPage {
 			$this->doPagerStuff();
 		} else {
 			$this->lookupRequest( $par );
+
+			$link = $this->getLinkRenderer()->makeKnownLink(
+				static::getSafeTitleFor( 'RequestWikiQueue' ),
+				$this->msg( 'requestwikiqueue' )->text()
+			);
+
+			$this->getOutput()->addSubtitle( "&lt; $link" );
+
 		}
 	}
 

--- a/includes/RequestWiki/SpecialRequestWikiQueue.php
+++ b/includes/RequestWiki/SpecialRequestWikiQueue.php
@@ -26,7 +26,7 @@ class SpecialRequestWikiQueue extends SpecialPage {
 			$this->getOutput()->addBacklinkSubtitle( $this->getPageTitle() );
 
 			$this->lookupRequest( $par );
-			}
+		}
 	}
 
 	private function doPagerStuff() {

--- a/includes/RequestWiki/SpecialRequestWikiQueue.php
+++ b/includes/RequestWiki/SpecialRequestWikiQueue.php
@@ -23,18 +23,10 @@ class SpecialRequestWikiQueue extends SpecialPage {
 		if ( $par === null || $par === '' ) {
 			$this->doPagerStuff();
 		} else {
+			$this->getOutput()->addBacklinkSubtitle( $this->getPageTitle() );
+
 			$this->lookupRequest( $par );
-
-			$this->getOutput()->setPageTitle( $this->msg( 'requestwikiqueue-request-view' )->text() );
-
-			$link = $this->getLinkRenderer()->makeKnownLink(
-				static::getSafeTitleFor( 'RequestWikiQueue' ),
-				$this->msg( 'requestwikiqueue' )->text()
-			);
-
-			$this->getOutput()->addSubtitle( "&lt; $link" );
-
-		}
+			}
 	}
 
 	private function doPagerStuff() {

--- a/includes/RequestWiki/SpecialRequestWikiQueue.php
+++ b/includes/RequestWiki/SpecialRequestWikiQueue.php
@@ -25,6 +25,8 @@ class SpecialRequestWikiQueue extends SpecialPage {
 		} else {
 			$this->lookupRequest( $par );
 
+			$this->getOutput()->setPageTitle( $this->msg( 'createwiki-viewrequest' )->text() );
+
 			$link = $this->getLinkRenderer()->makeKnownLink(
 				static::getSafeTitleFor( 'RequestWikiQueue' ),
 				$this->msg( 'requestwikiqueue' )->text()


### PR DESCRIPTION
This PR adds a link from wiki requests back to the wiki request queue, akin to how subpages have a link under them which links back to the main page. Useful for requesters and for WCs to quickly go back to the queue.