### PR TITLE
Do not show creation form if blocked

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -116,7 +116,7 @@ class RequestWikiRequestViewer {
 			];
 		}
 
-		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) || $userR->getId() == $request->requester->getId() ) {
+		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) && !$userR->getBlock() || $userR->getId() == $request->requester->getId() ) {
 			$formDescriptor += [
 				'comment' => [
 					'type' => 'textarea',
@@ -208,7 +208,7 @@ class RequestWikiRequestViewer {
 			];
 		}
 
-		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) ) {
+		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) && !$userR->getBlock() ) {
 			$visibilityOptions = [
 				0 => wfMessage( 'requestwikiqueue-request-label-visibility-all' )->text(),
 				1 => wfMessage( 'requestwikiqueue-request-label-visibility-hide' )->text(),


### PR DESCRIPTION
If a user with `createwiki` is blocked, they cannot access CreateWiki or RequestWiki but they can still create wikis. This doesn't make much sense as if a user is blocked, it's for a reason so this patches that logic flaw.