### PR TITLE
revert access change without prior discussion

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -116,7 +116,7 @@ class RequestWikiRequestViewer {
 			];
 		}
 
-		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) && !$userR->getBlock() || $userR->getId() == $request->requester->getId() ) {
+		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) || $userR->getId() == $request->requester->getId() ) {
 			$formDescriptor += [
 				'comment' => [
 					'type' => 'textarea',
@@ -208,7 +208,7 @@ class RequestWikiRequestViewer {
 			];
 		}
 
-		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) && !$userR->getBlock() ) {
+		if ( $permissionManager->userHasRight( $userR, 'createwiki' ) ) {
 			$visibilityOptions = [
 				0 => wfMessage( 'requestwikiqueue-request-label-visibility-all' )->text(),
 				1 => wfMessage( 'requestwikiqueue-request-label-visibility-hide' )->text(),


### PR DESCRIPTION
Previous behavior was intentional and user admitted it themself at a prior time. This is not a "logic flaw" and exists to seperate the duties of Meta sysops and Stewards. A change like this should not be done with a user merging their own change. Using commits to enact access changes goes outside the bounds of SRE