### PR TITLE
Don’t use CreateWikiUseSecureContainers

### DIFF
--- a/includes/RemoteWiki.php
+++ b/includes/RemoteWiki.php
@@ -204,12 +204,10 @@ class RemoteWiki {
 			'new' => 1
 		];
 
-		if ( $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
-			$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
-			$jobQueueGroupFactory->makeJobQueueGroup( $this->dbname )->push(
-				new SetContainersAccessJob( [ 'private' => true ] )
-			);
-		}
+		$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
+		$jobQueueGroupFactory->makeJobQueueGroup( $this->dbname )->push(
+			new SetContainersAccessJob( [ 'private' => true ] )
+		);
 
 		$this->hooks[] = 'CreateWikiStatePrivate';
 		$this->private = true;
@@ -222,12 +220,10 @@ class RemoteWiki {
 			'new' => 1
 		];
 
-		if ( $this->config->get( 'CreateWikiUseSecureContainers' ) ) {
-			$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
-			$jobQueueGroupFactory->makeJobQueueGroup( $this->dbname )->push(
-				new SetContainersAccessJob( [ 'private' => false ] )
-			);
-		}
+		$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
+		$jobQueueGroupFactory->makeJobQueueGroup( $this->dbname )->push(
+			new SetContainersAccessJob( [ 'private' => false ] )
+		);
 
 		$this->hooks[] = 'CreateWikiStatePublic';
 		$this->private = false;


### PR DESCRIPTION
We now do this logic within a new config CreateWikiContainers which allows more finer tuning.