### PR TITLE
RequestWiki use zero instead of null if values missing

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -361,11 +361,11 @@ class RequestWikiRequestViewer {
 
 			$request->sitename = $formData['edit-sitename'];
 			$request->language = $formData['edit-language'];
-			$request->purpose = $formData['edit-purpose'];
+			$request->purpose = $formData['edit-purpose'] ?? '';
 			$request->description = $formData['edit-description'];
-			$request->category = $formData['edit-category'];
-			$request->private = $formData['edit-private'];
-			$request->bio = $formData['edit-bio'];
+			$request->category = $formData['edit-category'] ?? '';
+			$request->private = $formData['edit-private'] ?? 0;
+			$request->bio = $formData['edit-bio'] ?? 0;
 
 			$request->reopen( $form->getUser() );
 		} elseif ( isset( $formData['submit-handle'] ) ) {

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -130,7 +130,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 		$request->language = $formData['language'];
 		$request->private = $formData['private'] ?? 0;
 		$request->requester = $this->getUser();
-		$request->category = $formData['category'];
+		$request->category = $formData['category'] ?? '';
 		$request->purpose = $formData['purpose'] ?? '';
 		$request->bio = $formData['bio'] ?? 0;
 


### PR DESCRIPTION
If the category, private, purpose, and bio features are turned off, these values will be missing from the form data. As the DB does not accept NULL for these values, we must fall back to a zero value.