### PR TITLE
Simplify the message createwiki-label-statuschangecomment

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -33,7 +33,7 @@
 	"createwiki-label-reason": "Describe the focus or purpose of this wiki:",
 	"createwiki-label-requester": "Requester:",
 	"createwiki-label-sitename": "Sitename:",
-	"createwiki-label-statuschangecomment": "Reason for giving for this action:",
+	"createwiki-label-statuschangecomment": "Reason for this action:",
 	"createwiki-success": "The wiki was successfully created.",
 	"echo-category-title-wiki-creation": "Wiki creation",
 	"echo-category-title-request-comment": "Comment added to wiki request",


### PR DESCRIPTION
The text "Reason for giving for this action" is hard to understand. "Reason for this action" is
hopefully clearer and more relevant.