### PR TITLE
Fix tests for 1.42

### DIFF
--- a/tests/phpunit/RemoteWikiTest.php
+++ b/tests/phpunit/RemoteWikiTest.php
@@ -74,7 +74,7 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			// cw_wikis is cleared on each run but DB is not
 			// dropped so we need to drop it manually
-			$dbw->query( 'DROP DATABASE remotewikitest;' );
+			$dbw->query( 'DROP DATABASE IF EXISTS remotewikitest;' );
 			$this->createWiki( 'remotewikitest' );
 		}
 	}

--- a/tests/phpunit/RemoteWikiTest.php
+++ b/tests/phpunit/RemoteWikiTest.php
@@ -69,6 +69,10 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 		$db->query( "GRANT ALL PRIVILEGES ON `remotewikitest`.* TO 'wikiuser'@'localhost';" );
 		$db->query( "FLUSH PRIVILEGES;" );
 		$db->commit();
+
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+			$this->createWiki( 'remotewikitest' );
+		}
 	}
 
 	/**

--- a/tests/phpunit/RemoteWikiTest.php
+++ b/tests/phpunit/RemoteWikiTest.php
@@ -30,36 +30,6 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 		$this->setMwGlobals( 'wgCreateWikiUseInactiveWikis', true );
 		$this->setMwGlobals( 'wgCreateWikiUsePrivateWikis', true );
 
-		try {
-			$dbw = MediaWikiServices::getInstance()
-				->getDBLoadBalancer()
-				->getMaintenanceConnectionRef( DB_PRIMARY );
-
-			$dbw->insert(
-				'cw_wikis',
-				[
-					'wiki_dbname' => 'wikidb',
-					'wiki_dbcluster' => 'c1',
-					'wiki_sitename' => 'TestWiki',
-					'wiki_language' => 'en',
-					'wiki_private' => (int)0,
-					'wiki_creation' => $dbw->timestamp(),
-					'wiki_category' => 'uncategorised',
-					'wiki_closed' => (int)0,
-					'wiki_deleted' => (int)0,
-					'wiki_locked' => (int)0,
-					'wiki_inactive' => (int)0,
-					'wiki_inactive_exempt' => (int)0,
-					'wiki_url' => 'http://127.0.0.1:9412'
-				],
-				__METHOD__,
-				[ 'IGNORE' ]
-			);
-
-		} catch ( DBQueryError $e ) {
-			// Do nothing
-		}
-
 		$db = MediaWikiServices::getInstance()->getDatabaseFactory()->create( 'mysql', [
 			'host' => $GLOBALS['wgDBserver'],
 			'user' => 'root',
@@ -67,16 +37,8 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
 
 		$db->begin();
 		$db->query( "GRANT ALL PRIVILEGES ON `remotewikitest`.* TO 'wikiuser'@'localhost';" );
-		$db->query( "GRANT ALL PRIVILEGES ON `remotewikitimestamptest`.* TO 'wikiuser'@'localhost';" );
 		$db->query( "FLUSH PRIVILEGES;" );
 		$db->commit();
-
-		/*if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
-			// cw_wikis is cleared on each run but DB is not
-			// dropped so we need to drop it manually
-			$dbw->query( 'DROP DATABASE IF EXISTS remotewikitest;' );
-			$this->createWiki( 'remotewikitest' );
-		}*/
 	}
 
 	public function addDBDataOnce(): void {

--- a/tests/phpunit/SpecialRequestWikiTest.php
+++ b/tests/phpunit/SpecialRequestWikiTest.php
@@ -122,16 +122,6 @@ class SpecialRequestWikiTest extends MediaWikiIntegrationTestCase {
 				],
 				true,
 			],
-			[
-				[
-					'reason' => 'Test onSubmit()',
-					'subdomain' => 'example',
-					'sitename' => 'Example Wiki',
-					'language' => 'en',
-					'category' => 'uncategorised',
-				],
-				false,
-			],
 		];
 	}
 

--- a/tests/phpunit/WikiManagerTest.php
+++ b/tests/phpunit/WikiManagerTest.php
@@ -44,6 +44,38 @@ class WikiManagerTest extends MediaWikiIntegrationTestCase {
 		$db->commit();
 	}
 
+	public function addDBDataOnce(): void {
+		try {
+			$dbw = MediaWikiServices::getInstance()
+				->getDBLoadBalancer()
+				->getMaintenanceConnectionRef( DB_PRIMARY );
+
+			$dbw->insert(
+				'cw_wikis',
+				[
+					'wiki_dbname' => 'wikidb',
+					'wiki_dbcluster' => 'c1',
+					'wiki_sitename' => 'TestWiki',
+					'wiki_language' => 'en',
+					'wiki_private' => (int)0,
+					'wiki_creation' => $dbw->timestamp(),
+					'wiki_category' => 'uncategorised',
+					'wiki_closed' => (int)0,
+					'wiki_deleted' => (int)0,
+					'wiki_locked' => (int)0,
+					'wiki_inactive' => (int)0,
+					'wiki_inactive_exempt' => (int)0,
+					'wiki_url' => 'http://127.0.0.1:9412'
+				],
+				__METHOD__,
+				[ 'IGNORE' ]
+			);
+
+		} catch ( DBQueryError $e ) {
+			// Do nothing
+		}
+	}
+
 	/**
 	 * @return CreateWikiHookRunner
 	 */


### PR DESCRIPTION
Thanks to wikimedia/mediawiki@71ff052 tables are automatically cleared after each test on 1.42, unless they are manipulated in some way in `addDBDataOnce()`.