### PR TITLE
Make on hold the first option when handling wiki requests

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -240,9 +240,9 @@ class RequestWikiRequestViewer {
 					'type' => 'radio',
 					'label-message' => 'requestwikiqueue-request-label-action',
 					'options-messages' => [
+						'requestwikiqueue-onhold' => 'onhold',
 						'requestwikiqueue-approve' => 'approve',
 						'requestwikiqueue-decline' => 'decline',
-						'requestwikiqueue-onhold' => 'onhold',
 					],
 					'default' => $request->getStatus(),
 					'cssclass' => 'createwiki-infuse',


### PR DESCRIPTION
This change is to prevent wiki requests from being approved by mistake