### PR TITLE
Rename query_wiki_request to wiki_request

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -94,9 +94,9 @@
 	},
 	"RestRoutes": [
 		{
-			"path": "/createwiki/v0/query_wiki_request/{id}",
+			"path": "/createwiki/v0/wiki_request/{id}",
 			"method": "GET",
-			"class": "Miraheze\\CreateWiki\\RequestWiki\\Handler\\QueryWikiRequest",
+			"class": "Miraheze\\CreateWiki\\RequestWiki\\Handler\\RestWikiRequest",
 			"services": [
 				"ConfigFactory",
 				"DBLoadBalancerFactory",

--- a/includes/RequestWiki/Handler/RestWikiRequest.php
+++ b/includes/RequestWiki/Handler/RestWikiRequest.php
@@ -11,10 +11,11 @@ use Wikimedia\Rdbms\ILBFactory;
 
 /**
  * Returns all information related to a wiki request
+ * TODO: Ability to handle, post comments, and file new wiki requests
  * Only publicly accessible wiki requests can be queried through this API
- * GET /createwiki/v0/query_wiki_request/{id}
+ * GET /createwiki/v0/wiki_request/{id}
  */
-class QueryWikiRequest extends SimpleHandler {
+class RestWikiRequest extends SimpleHandler {
 
 	/** @var Config */
 	private $config;


### PR DESCRIPTION
This handler will also be used for handling wiki requests and filing new wiki requests in the future