### PR TITLE
Remove checks for `(read)`

### DIFF
--- a/includes/RequestWiki/Handler/RestWikiRequest.php
+++ b/includes/RequestWiki/Handler/RestWikiRequest.php
@@ -68,7 +68,7 @@ class RestWikiRequest extends SimpleHandler {
 			 * being revealed to local suppressors/sysops
 			 */
 
-			if ( $wikiRequestVisibility !== 'read' && $this->getAuthority()->isAllowed( 'read' ) ) {
+			if ( $wikiRequestVisibility !== 'read' ) {
 				if ( !$this->getAuthority()->isAllowedAll( 'createwiki', $wikiRequestVisibility ) ) {
 					// User does not have permission to view this request
 					return $this->getResponseFactory()->createHttpError( 404, ['message' => 'Request not found'] );

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -44,7 +44,7 @@ class RequestWikiRequestViewer {
 		// but if we can't view the request, it also doesn't exist
 		$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
 
-		if ( $visibilityConds[$request->visibility] !== 'read' && $permissionManager->userHasRight( $userR, 'read' ) ) {
+		if ( $visibilityConds[$request->visibility] !== 'read' ) {
 			if ( !$permissionManager->userHasAllRights( $userR, 'createwiki', $visibilityConds[$request->visibility] ) ) {
 				$context->getOutput()->addHTML( Html::errorBox( wfMessage( 'requestwiki-unknown' )->escaped() ) );
 


### PR DESCRIPTION
Unnecessary checks, since if the user doesn't have this perm it should not be able to reach the special pages or APIs to begin with.