### PR TITLE
Drop old code

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -403,7 +403,6 @@ class RequestWikiRequestViewer {
 
 			$request->reopen( $form->getUser() );
 		} elseif ( isset( $formData['submit-handle'] ) ) {
-			$request->visibility = $formData['visibility'];
 			if ( isset( $formData['visibility-options'] ) ) {
 				$request->suppress( $user, $formData['visibility-options'] );
 			}


### PR DESCRIPTION
This code was responsible for https://issue-tracker.miraheze.org/T11993, CVE-2024-29883.

Once that was fixed this line became useless, but was never removed.