### PR TITLE
Fix comparison between requested and current suppression level

### DIFF
--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -303,7 +303,7 @@ class WikiRequest {
 	}
 
 	public function suppress( User $user, int $level, $log = true ) {
-		if ( $level === $this->visibility ) {
+		if ( $level === (int)$this->visibility ) {
 			// Nothing to do, the wiki request already has the requested suppression level
 			return;
 		}


### PR DESCRIPTION
Everything from the database is stored by MediaWiki as a string. A string will never be === to an int, preventing this check from working