### PR TITLE
remove top from oo-ui-menuSelectWidget

### DIFF
--- a/modules/ext.createwiki.oouiform.ooui.less
+++ b/modules/ext.createwiki.oouiform.ooui.less
@@ -17,12 +17,6 @@
 	}
 }
 
-.mw-special-RequestWikiQueue {
-	.oo-ui-menuSelectWidget {
-		top: 0;
-	}
-}
-
 #createwiki {
 	filter: brightness( 1 );
 }


### PR DESCRIPTION
Breaks the form element. Whatever reason this was originally here for probably no longer applies.

It appears a change to the OOUI elements makes it so that the top property is not automatically generated for the element if it already has one custom applied.

Bug: T12265