### PR TITLE
Make Special:RequestWikiQueue respect the timezone set by the user

### DIFF
--- a/includes/RequestWiki/RequestWikiQueuePager.php
+++ b/includes/RequestWiki/RequestWikiQueuePager.php
@@ -60,7 +60,7 @@ class RequestWikiQueuePager extends TablePager {
 
 		switch ( $name ) {
 			case 'cw_timestamp':
-				$formatted = $language->timeanddate( $row->cw_timestamp );
+				$formatted = $language->timeanddate( $row->cw_timestamp, true );
 				break;
 			case 'cw_dbname':
 				$formatted = $row->cw_dbname;


### PR DESCRIPTION
In Special:RequestWikiQueue, the "requested date" was displayed as UTC time regardless of the user's preference, so this should be changed to respect the user's time zone preference. Note that Special:RequestWikiQueue/[id] already respects the user's time zone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced timestamp formatting for better clarity in date and time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->