### PR TITLE
Add Request Lock to RequestWiki

### DIFF
--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -264,6 +264,12 @@ class RequestWikiRequestViewer {
 					'cssclass' => 'createwiki-infuse',
 					'section' => 'handle',
 				],
+				'lock' => [
+					'type' => 'check',
+					'label' => 'createwiki-label-lock' // TODO: Add message to interface
+					'cssclass' => 'createwiki-infuse',
+					'section' => 'handle',
+				],
 				'visibility' => [
 					'type' => 'check',
 					'label-message' => 'revdelete-legend',
@@ -426,6 +432,7 @@ class RequestWikiRequestViewer {
 				$request->decline( $formData['reason'], $user );
 			}
 		}
+		$request->setLock($formData['lock'])
 
 		$out->addHTML(
 			Html::successBox(

--- a/includes/RequestWiki/RequestWikiRequestViewer.php
+++ b/includes/RequestWiki/RequestWikiRequestViewer.php
@@ -266,7 +266,7 @@ class RequestWikiRequestViewer {
 				],
 				'lock' => [
 					'type' => 'check',
-					'label' => 'createwiki-label-lock' // TODO: Add message to interface
+					'label' => 'createwiki-label-lock', // TODO: Add message to interface
 					'cssclass' => 'createwiki-infuse',
 					'section' => 'handle',
 				],
@@ -432,7 +432,7 @@ class RequestWikiRequestViewer {
 				$request->decline( $formData['reason'], $user );
 			}
 		}
-		$request->setLock($formData['lock'])
+		$request->lock = $formData['lock'];
 
 		$out->addHTML(
 			Html::successBox(

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -26,6 +26,7 @@ class WikiRequest {
 	public $requester;
 	public $timestamp;
 	public $bio;
+	public $lock;
 	public $purpose;
 
 	private $id;
@@ -70,6 +71,7 @@ class WikiRequest {
 			$this->timestamp = $dbRequest->cw_timestamp;
 			$this->visibility = (int)$dbRequest->cw_visibility;
 			$this->bio = $dbRequest->cw_bio;
+			$this->lock = $dbRequest->cw_lock;
 
 			$newDesc = explode( "\n", $dbRequest->cw_comment, 2 );
 			$purposeCheck = explode( ':', $newDesc[0], 2 );
@@ -169,6 +171,9 @@ class WikiRequest {
 		return $this->visibility;
 	}
 
+	public function getLocked(): bool {
+		return $this->lock;
+	}
 	public function approve( UserIdentity $user, string $reason = null ) {
 		if ( $this->config->get( 'CreateWikiUseJobQueue' ) ) {
 			$jobParams = [

--- a/includes/RequestWiki/WikiRequest.php
+++ b/includes/RequestWiki/WikiRequest.php
@@ -393,6 +393,7 @@ class WikiRequest {
 			'cw_category' => $this->category,
 			'cw_visibility' => $this->visibility,
 			'cw_bio' => $this->bio,
+			'cw_lock' => $this->lock
 		];
 
 		if ( !$this->id ) {

--- a/sql/cw_requests.sql
+++ b/sql/cw_requests.sql
@@ -11,6 +11,6 @@ CREATE TABLE /*_*/cw_requests (
   cw_user INT(10) NOT NULL,
   cw_category VARCHAR(64) NOT NULL,
   cw_visibility TINYINT UNSIGNED NOT NULL DEFAULT '0',
-  cw_bio TINYINT UNSIGNED NOT NULL DEFAULT '0'
+  cw_bio TINYINT UNSIGNED NOT NULL DEFAULT '0',
   cw_lock TINYINT UNSIGNED NOT NULL DEFAULT '0'
 ) /*$wgDBTableOptions*/;

--- a/sql/cw_requests.sql
+++ b/sql/cw_requests.sql
@@ -12,5 +12,5 @@ CREATE TABLE /*_*/cw_requests (
   cw_category VARCHAR(64) NOT NULL,
   cw_visibility TINYINT UNSIGNED NOT NULL DEFAULT '0',
   cw_bio TINYINT UNSIGNED NOT NULL DEFAULT '0'
-  cw_lock TINYINT NOT NULL DEFAULT '0'
+  cw_lock TINYINT UNSIGNED NOT NULL DEFAULT '0'
 ) /*$wgDBTableOptions*/;

--- a/sql/cw_requests.sql
+++ b/sql/cw_requests.sql
@@ -12,4 +12,5 @@ CREATE TABLE /*_*/cw_requests (
   cw_category VARCHAR(64) NOT NULL,
   cw_visibility TINYINT UNSIGNED NOT NULL DEFAULT '0',
   cw_bio TINYINT UNSIGNED NOT NULL DEFAULT '0'
+  cw_lock TINYINT NOT NULL DEFAULT '0'
 ) /*$wgDBTableOptions*/;

--- a/sql/patches/patch-cw_requests-add-cw_lock.sql
+++ b/sql/patches/patch-cw_requests-add-cw_lock.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*$wgDBprefix*/cw_requests
+  ADD COLUMN cw_lock TINYINT UNSIGNED NOT NULL DEFAULT '0';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a locking mechanism for wiki requests, allowing users to specify if a wiki page should be locked during creation.
  - Added a new checkbox field for locking functionality in the wiki creation form.

- **Bug Fixes**
  - Improved handling of request locking logic during form submission.

- **Database Changes**
  - Added a `cw_lock` column to the `cw_requests` table, enabling tracking of lock states for requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->