### PR TITLE
Require agreement checkbox to be checked if defined

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -19,6 +19,7 @@
 	"createwiki-close-email-sender": "Miraheze",
 	"createwiki-email-subject": "Your new Miraheze wiki ($1) has been created",
 	"createwiki-email-body": "Hello!\n\nYou recently requested a wiki on Miraheze. We are pleased to inform you that it has been approved!\n\nMiraheze is here to help you every step of the way, don't be afraid to ask! Visit our <a href=\"https://meta.miraheze.org/wiki/Special:MyLanguage/Help_center\">Help center</a> for detailed help on a range of topics, such as managing your wiki using our ManageWiki tool, using images and templates, filing tasks, and more!\n\nPlease remember that all wikis must abide by the <a href=\"https://meta.miraheze.org/wiki/Special:MyLanguage/Content_Policy\">Content Policy</a> or they may be closed. Remember that your wiki cannot deviate too much from its approved purpose or it may be closed too.\n\nThank you for choosing Miraheze! We wish you all the best on your new wiki adventure.",
+	"createwiki-error-agreement": "You must agree to this service's terms.",
 	"createwiki-error-dbexists": "'''NOTE''': A wiki with this subdomain already exists.",
 	"createwiki-error-disallowed": "The subdomain you have requested is unavailable. Please select another subdomain.",
 	"createwiki-error-notalnum": "The subdomain selected contains non-alphanumeric characters. Please try again.",

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -14,6 +14,7 @@ use MediaWiki\Title\Title;
 use Miraheze\CreateWiki\CreateWikiRegexConstraint;
 use Miraheze\CreateWiki\EntryPointUtils;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
+use Status;
 
 class SpecialRequestWiki extends FormSpecialPage {
 
@@ -147,6 +148,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 				'label-message' => 'requestwiki-label-agreement',
 				'help-message' => 'requestwiki-help-agreement',
 				'required' => true,
+				'validation-callback' => [ $this, 'isAgreementChecked' ],
 			];
 		}
 
@@ -240,6 +242,14 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 		if ( !$reason || ctype_space( $reason ) ) {
 			return $this->msg( 'htmlform-required', 'parseinline' )->escaped();
+		}
+
+		return true;
+	}
+
+	public function isAgreementChecked( bool $agreement ) {
+		if ( !$agreement ) {
+			return Status::newFatal( 'createwiki-error-agreement' )->getMessage();
 		}
 
 		return true;

--- a/includes/RequestWiki/SpecialRequestWiki.php
+++ b/includes/RequestWiki/SpecialRequestWiki.php
@@ -14,7 +14,7 @@ use MediaWiki\Title\Title;
 use Miraheze\CreateWiki\CreateWikiRegexConstraint;
 use Miraheze\CreateWiki\EntryPointUtils;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
-use Status;
+use StatusValue;
 
 class SpecialRequestWiki extends FormSpecialPage {
 
@@ -249,7 +249,7 @@ class SpecialRequestWiki extends FormSpecialPage {
 
 	public function isAgreementChecked( bool $agreement ) {
 		if ( !$agreement ) {
-			return Status::newFatal( 'createwiki-error-agreement' )->getMessage();
+			return StatusValue::newFatal( 'createwiki-error-agreement' );
 		}
 
 		return true;


### PR DESCRIPTION
Currently, it's just a browser-side warning but a server-side check would be useful.