### PR TITLE
Add MissingWikiError exception

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -26,6 +26,7 @@
 	"createwiki-error-cannot-edit-approved": "You cannot edit a request that has already been approved.",
 	"createwiki-error-dbexists": "'''NOTE''': A wiki with this subdomain already exists.",
 	"createwiki-error-disallowed": "The subdomain you have requested is unavailable. Please select another subdomain.",
+	"createwiki-error-missingwiki": "The wiki '$1' does not exist.",
 	"createwiki-error-notalnum": "The subdomain you have selected contains non-alphanumeric characters. Please try again.",
 	"createwiki-error-notlowercase": "The subdomain may not contain uppercase letters. Please try again.",
 	"createwiki-error-notsuffixed": "The database name doesn't end with a valid suffix ('$1').",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -33,6 +33,7 @@
 	"createwiki-error-cannot-edit-approved": "Error message when attempting to edit a wiki request that has already been approved.",
 	"createwiki-error-dbexists": "Used as error message when the database being created already exists.",
 	"createwiki-error-disallowed": "Error message displayed when a disallowed subdomain is entered in the wiki request form.",
+	"createwiki-error-missingwiki": "Error message given when a wiki does not exist. $1 is the wiki database name.",
 	"createwiki-error-notalnum": "Used as error message when the database name entered does not contain non-alphanumeric characters.",
 	"createwiki-error-notlowercase": "Used as error message when the database name entered contains uppercase letters.",
 	"createwiki-error-notsuffixed": "Used as error message when the database name enter does not contain the suffix. $1 represents the allowed suffix.",

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -10,7 +10,7 @@ use RuntimeException;
 class MissingWikiError extends ErrorPageError {
 
 	public function __construct( string $msg, array $params ) {
-		if ( !self::isCommandLine() ) {
+		if ( self::isCommandLine() ) {
 			throw new RuntimeException(
 				wfMessage( $msg, $params )->inContentLanguage()->text()
 			);

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -12,7 +12,7 @@ class MissingWikiError extends ErrorPageError {
 	public function __construct( string $msg, array $params ) {
 		if ( !self::isCommandLine() ) {
 			throw new RuntimeException(
-				wfMessage( $msg, $params )->text()
+				wfMessage( $msg, $params )->inContentLanguage()->text()
 			);
 		}
 

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -15,7 +15,7 @@ class MissingWikiError extends ErrorPageError {
 				wfMessage( $msg, $params )->inContentLanguage()->escaped()
 			);
 		}
-			
+
 		$errorBody = new RawMessage( Html::errorBox( wfMessage( $msg, $params )->parse() ) );
 		parent::__construct( 'errorpagetitle', $errorBody, [] );
 	}

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -12,7 +12,7 @@ class MissingWikiError extends ErrorPageError {
 	public function __construct( string $msg, array $params ) {
 		if ( !self::isCommandLine() ) {
 			throw new RuntimeException(
-				wfMessage( $msg, $params )->inContentLanguage()->text()
+				wfMessage( $msg, $params )->text()
 			);
 		}
 

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -12,7 +12,7 @@ class MissingWikiError extends ErrorPageError {
 	public function __construct( string $msg, array $params ) {
 		if ( !self::isCommandLine() ) {
 			throw new RuntimeException(
-				wfMessage( $msg, $params )->inContentLanguage()->escaped()
+				wfMessage( $msg, $params )->inContentLanguage()->text()
 			);
 		}
 

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -5,10 +5,17 @@ namespace Miraheze\CreateWiki\Exceptions;
 use ErrorPageError;
 use MediaWiki\Html\Html;
 use MediaWiki\Language\RawMessage;
+use RuntimeException;
 
 class MissingWikiError extends ErrorPageError {
 
 	public function __construct( string $msg, array $params ) {
+		if ( !self::isCommandLine() ) {
+			throw new RuntimeException(
+				wfMessage( $msg, $params )->inContentLanguage()->escaped()
+			);
+		}
+			
 		$errorBody = new RawMessage( Html::errorBox( wfMessage( $msg, $params )->parse() ) );
 		parent::__construct( 'errorpagetitle', $errorBody, [] );
 	}

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Miraheze\CreateWiki\Exceptions;
+
+use ErrorPageError;
+use MediaWiki\Html\Html;
+use MediaWiki\Language\RawMessage;
+
+class MissingWikiError extends ErrorPageError {
+	public function __construct( string $msg, array $params ) {
+		$errorBody = new RawMessage( Html::errorBox( wfMessage( $msg, $params )->parse() ) );
+		parent::__construct( 'errorpagetitle', $errorBody, [] );
+	}
+}

--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -7,6 +7,7 @@ use MediaWiki\Html\Html;
 use MediaWiki\Language\RawMessage;
 
 class MissingWikiError extends ErrorPageError {
+
 	public function __construct( string $msg, array $params ) {
 		$errorBody = new RawMessage( Html::errorBox( wfMessage( $msg, $params )->parse() ) );
 		parent::__construct( 'errorpagetitle', $errorBody, [] );

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -2,7 +2,6 @@
 
 namespace Miraheze\CreateWiki\Services;
 
-use InvalidArgumentException;
 use JobSpecification;
 use MediaWiki\Config\ServiceOptions;
 use MediaWiki\JobQueue\JobQueueGroupFactory;

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -7,6 +7,7 @@ use JobSpecification;
 use MediaWiki\Config\ServiceOptions;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use Miraheze\CreateWiki\ConfigNames;
+use Miraheze\CreateWiki\Exceptions\MissingWikiError;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\Jobs\SetContainersAccessJob;
 use UnexpectedValueException;
@@ -90,7 +91,7 @@ class RemoteWikiFactory {
 			->fetchRow();
 
 		if ( !$row ) {
-			throw new InvalidArgumentException( "Wiki '$wiki' cannot be found." );
+			throw new MissingWikiError( 'createwiki-error-missingwiki', [ $wiki ] );
 		}
 
 		$this->dbname = $wiki;


### PR DESCRIPTION
If we don't throw anywhere like before #567, then we now get something like `Error: Typed property Miraheze\CreateWiki\Services\RemoteWikiFactory::$locked must not be accessed before initialization`, so we need to throw an error, but also, like before, we want it to be a nice user-friendly message, so we do a custom exception that extends `ErrorPageError` and shows the error in a nice errorBox.