### PR TITLE
Remove unneeded comments where it only says param or return types

### DIFF
--- a/includes/CreateWiki/CreateWikiLogFormatter.php
+++ b/includes/CreateWiki/CreateWikiLogFormatter.php
@@ -12,10 +12,6 @@ class CreateWikiLogFormatter extends LogFormatter {
 
 	private LinkRenderer $linkRenderer;
 
-	/**
-	 * @param LogEntry $entry
-	 * @param LinkRenderer $linkRenderer
-	 */
 	public function __construct(
 		LogEntry $entry,
 		LinkRenderer $linkRenderer
@@ -24,9 +20,7 @@ class CreateWikiLogFormatter extends LogFormatter {
 		$this->linkRenderer = $linkRenderer;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	/** @inheritDoc */
 	protected function getMessageParameters(): array {
 		$params = parent::getMessageParameters();
 		$subtype = $this->entry->getSubtype();

--- a/includes/CreateWiki/SpecialCreateWiki.php
+++ b/includes/CreateWiki/SpecialCreateWiki.php
@@ -14,9 +14,6 @@ class SpecialCreateWiki extends FormSpecialPage {
 
 	private WikiManagerFactory $wikiManagerFactory;
 
-	/**
-	 * @param WikiManagerFactory $wikiManagerFactory
-	 */
 	public function __construct( WikiManagerFactory $wikiManagerFactory ) {
 		parent::__construct( 'CreateWiki', 'createwiki' );
 		$this->wikiManagerFactory = $wikiManagerFactory;
@@ -33,9 +30,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 		parent::execute( $par );
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	/** @inheritDoc */
 	protected function getFormFields(): array {
 		$formDescriptor = [
 			'dbname' => [
@@ -89,9 +84,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 		return $formDescriptor;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	/** @inheritDoc */
 	public function onSubmit( array $formData ): bool {
 		if ( $this->getConfig()->get( ConfigNames::UsePrivateWikis ) ) {
 			$private = $formData['private'];
@@ -142,16 +135,12 @@ class SpecialCreateWiki extends FormSpecialPage {
 		return true;
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	/** @inheritDoc */
 	protected function getDisplayFormat(): string {
 		return 'ooui';
 	}
 
-	/**
-	 * @inheritDoc
-	 */
+	/** @inheritDoc */
 	protected function getGroupName(): string {
 		return 'wikimanage';
 	}

--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -28,9 +28,6 @@ class CreateWikiHookRunner implements
 
 	private HookContainer $hookContainer;
 
-	/**
-	 * @param HookContainer $hookContainer
-	 */
 	public function __construct( HookContainer $hookContainer ) {
 		$this->hookContainer = $hookContainer;
 	}

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -34,12 +34,6 @@ class Main implements
 	private RemoteWikiFactory $remoteWikiFactory;
 	private IConnectionProvider $connectionProvider;
 
-	/**
-	 * @param ConfigFactory $configFactory
-	 * @param IConnectionProvider $connectionProvider
-	 * @param CreateWikiDataFactory $dataFactory
-	 * @param RemoteWikiFactory $remoteWikiFactory
-	 */
 	public function __construct(
 		ConfigFactory $configFactory,
 		IConnectionProvider $connectionProvider,

--- a/includes/Jobs/CreateWikiJob.php
+++ b/includes/Jobs/CreateWikiJob.php
@@ -49,9 +49,6 @@ class CreateWikiJob extends Job {
 		$this->wikiRequestManager = $wikiRequestManager;
 	}
 
-	/**
-	 * @return bool
-	 */
 	public function run(): bool {
 		$this->wikiRequestManager->loadFromID( $this->id );
 		$wikiManager = $this->wikiManagerFactory->newInstance( $this->dbname );

--- a/includes/Services/CreateWikiNotificationsManager.php
+++ b/includes/Services/CreateWikiNotificationsManager.php
@@ -29,12 +29,6 @@ class CreateWikiNotificationsManager {
 	private UserFactory $userFactory;
 	private string $type;
 
-	/**
-	 * @param IConnectionProvider $connectionProvider
-	 * @param MessageLocalizer $messageLocalizer
-	 * @param ServiceOptions $options
-	 * @param UserFactory $userFactory
-	 */
 	public function __construct(
 		IConnectionProvider $connectionProvider,
 		MessageLocalizer $messageLocalizer,
@@ -50,9 +44,6 @@ class CreateWikiNotificationsManager {
 		$this->userFactory = $userFactory;
 	}
 
-	/**
-	 * @return string
-	 */
 	private function getFromName(): string {
 		if ( $this->type === 'closure' ) {
 			return $this->messageLocalizer->msg( 'createwiki-close-email-sender' )
@@ -66,9 +57,6 @@ class CreateWikiNotificationsManager {
 		return 'CreateWiki Notifications';
 	}
 
-	/**
-	 * @return array
-	 */
 	private function getEmailTypes(): array {
 		return [
 			'closure',
@@ -78,9 +66,6 @@ class CreateWikiNotificationsManager {
 		];
 	}
 
-	/**
-	 * @return array
-	 */
 	private function getEchoTypes(): array {
 		return [
 			'request-comment',
@@ -90,9 +75,6 @@ class CreateWikiNotificationsManager {
 		];
 	}
 
-	/**
-	 * @return array
-	 */
 	private function notifyServerAdministratorsTypes(): array {
 		return [
 			'deletion',
@@ -100,10 +82,6 @@ class CreateWikiNotificationsManager {
 		];
 	}
 
-	/**
-	 * @param array $data
-	 * @param string $wiki
-	 */
 	public function notifyBureaucrats( array $data, string $wiki ): void {
 		$dbr = $this->connectionProvider->getReplicaDatabase( $wiki );
 
@@ -126,10 +104,6 @@ class CreateWikiNotificationsManager {
 		$this->sendNotification( $data, $emails );
 	}
 
-	/**
-	 * @param array $data
-	 * @param array $receivers
-	 */
 	public function sendNotification( array $data, array $receivers ): void {
 		$this->type = $data['type'];
 
@@ -148,10 +122,6 @@ class CreateWikiNotificationsManager {
 		}
 	}
 
-	/**
-	 * @param array $data
-	 * @param array $receivers
-	 */
 	private function sendEchoNotification( array $data, array $receivers ): void {
 		foreach ( $receivers as $receiver ) {
 			$user = is_object( $receiver ) ? $receiver :
@@ -169,10 +139,6 @@ class CreateWikiNotificationsManager {
 		}
 	}
 
-	/**
-	 * @param array $data
-	 * @param array $receivers
-	 */
 	private function sendEmailNotification( array $data, array $receivers ): void {
 		DeferredUpdates::addCallableUpdate( function () use ( $data, $receivers ) {
 			$notifyEmails = [];


### PR DESCRIPTION
Type hints tell you this so the docs are unnecessary if they don't explain anything else.