### PR TITLE
RequestWikiQueuePager: Set default to always sort ascending

### DIFF
--- a/includes/RequestWiki/RequestWikiQueuePager.php
+++ b/includes/RequestWiki/RequestWikiQueuePager.php
@@ -16,6 +16,8 @@ use Wikimedia\Rdbms\IConnectionProvider;
 
 class RequestWikiQueuePager extends TablePager {
 
+	public $mDefaultDirection = IndexPager::DIR_ASCENDING;
+
 	private LanguageNameUtils $languageNameUtils;
 	private LinkRenderer $linkRenderer;
 	private UserFactory $userFactory;
@@ -41,16 +43,9 @@ class RequestWikiQueuePager extends TablePager {
 	) {
 		$this->mDb = $connectionProvider->getReplicaDatabase( 'virtual-createwiki-central' );
 
-		$this->linkRenderer = $linkRenderer;
-
-		if ( $context->getRequest()->getText( 'sort', 'cw_timestamp' ) == 'cw_timestamp' ) {
-			$this->mDefaultDirection = IndexPager::DIR_DESCENDING;
-		} else {
-			$this->mDefaultDirection = IndexPager::DIR_ASCENDING;
-		}
-
 		parent::__construct( $context, $linkRenderer );
 
+		$this->linkRenderer = $linkRenderer;
 		$this->languageNameUtils = $languageNameUtils;
 		$this->userFactory = $userFactory;
 		$this->wikiRequestManager = $wikiRequestManager;

--- a/includes/RequestWiki/RequestWikiQueuePager.php
+++ b/includes/RequestWiki/RequestWikiQueuePager.php
@@ -16,6 +16,7 @@ use Wikimedia\Rdbms\IConnectionProvider;
 
 class RequestWikiQueuePager extends TablePager {
 
+	/** @inheritDoc */
 	public $mDefaultDirection = IndexPager::DIR_ASCENDING;
 
 	private LanguageNameUtils $languageNameUtils;


### PR DESCRIPTION
As requested by most wiki creators, sorting by descending timestamp is annoying: https://github.com/miraheze/CreateWiki/commit/4b0c08049334fc4a7207f5e2147ac28f9c0bae8a#commitcomment-149696533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default sorting direction for request queues, now consistently set to ascending order.
  
- **Bug Fixes**
	- Removed conditional logic that affected sorting behavior based on request parameters, ensuring a more predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->