### PR TITLE
Remove CreateWiki AI from all isVisibilityAllowed

### DIFF
--- a/includes/Services/WikiRequestManager.php
+++ b/includes/Services/WikiRequestManager.php
@@ -348,12 +348,6 @@ class WikiRequestManager {
 			return true;
 		}
 
-		// CreateWiki AI should be able to see this.
-		// Additionally, the username is reserved.
-		if ( $user->getName() === 'CreateWiki AI' ) {
-			return true;
-		}
-
 		return $this->permissionManager->userHasRight(
 			$user, self::VISIBILITY_CONDS[$visibility]
 		);


### PR DESCRIPTION
1) This shouldn't need it, it runs on the DB and just uses it for comments etc... shouldn't actually need the (system) account to see this.
2) Even if it doesn't work for hidden requests without it, we don't need to run this (and shouldn't) on suppressed requests anyway.