### PR TITLE
Fix escaping NULL database records

### DIFF
--- a/includes/RequestWiki/RequestWikiQueuePager.php
+++ b/includes/RequestWiki/RequestWikiQueuePager.php
@@ -58,10 +58,10 @@ class RequestWikiQueuePager extends TablePager {
 				) );
 				break;
 			case 'cw_dbname':
-				$formatted = $this->escape( $row->cw_dbname );
+				$formatted = $this->escape( $row->cw_dbname ?? '' );
 				break;
 			case 'cw_sitename':
-				$formatted = $this->escape( $row->cw_sitename );
+				$formatted = $this->escape( $row->cw_sitename ?? '' );
 				break;
 			case 'cw_user':
 				$formatted = Linker::userLink(
@@ -70,7 +70,7 @@ class RequestWikiQueuePager extends TablePager {
 				);
 				break;
 			case 'cw_url':
-				$formatted = $this->escape( $row->cw_url );
+				$formatted = $this->escape( $row->cw_url ?? '' );
 				break;
 			case 'cw_status':
 				$formatted = $this->linkRenderer->makeLink(


### PR DESCRIPTION
Reported on the Miraheze Community Roles Discord server: <https://discord.com/channels/1006797886027214949/1225518258451517492/1344271653915332641>

Exception message and relevant stacktrace:
```
[5e07db8fea2c2e887869264a] /wiki/Special:RequestWikiQueue?dbname=&language=*&requester=&status=declined   TypeError: Miraheze\CreateWiki\RequestWiki\RequestWikiQueuePager::escape(): Argument #1 ($value) must be of type string, null given, called in /srv/mediawiki/1.43/extensions/CreateWiki/includes/RequestWiki/RequestWikiQueuePager.php on line 64

from /srv/mediawiki/1.43/extensions/CreateWiki/includes/RequestWiki/RequestWikiQueuePager.php(97) 0 /srv/mediawiki/1.43/extensions/CreateWiki/includes/RequestWiki/RequestWikiQueuePager.php(64): Miraheze\CreateWiki\RequestWiki\RequestWikiQueuePager->escape(null)
```