### PR TITLE
Only pass wiki to MissingWikiError

### DIFF
--- a/includes/Exceptions/MissingWikiError.php
+++ b/includes/Exceptions/MissingWikiError.php
@@ -4,7 +4,7 @@ namespace Miraheze\CreateWiki\Exceptions;
 
 class MissingWikiError extends ErrorBase {
 
-	public function __construct( string $msg, array $params ) {
-		parent::__construct( $msg, $params );
+	public function __construct( string $wiki ) {
+		parent::__construct( 'createwiki-error-missingwiki', [ $wiki ] );
 	}
 }

--- a/includes/Services/CreateWikiDataFactory.php
+++ b/includes/Services/CreateWikiDataFactory.php
@@ -207,7 +207,7 @@ class CreateWikiDataFactory {
 				return;
 			}
 
-			throw new MissingWikiError( 'createwiki-error-missingwiki', [ $this->wiki ] );
+			throw new MissingWikiError( $this->wiki );
 		}
 
 		$states = [];

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -73,7 +73,7 @@ class RemoteWikiFactory {
 			->fetchRow();
 
 		if ( !$row ) {
-			throw new MissingWikiError( 'createwiki-error-missingwiki', [ $wiki ] );
+			throw new MissingWikiError( $wiki );
 		}
 
 		$this->dbname = $wiki;


### PR DESCRIPTION
Improves type hinting (ensuring wiki is a string) and reduces duplication (don't have to manually have to keep passing the same message key)