### PR TITLE
Don't run onCreateWikiRename in maintenance script

### DIFF
--- a/maintenance/renameWiki.php
+++ b/maintenance/renameWiki.php
@@ -42,7 +42,6 @@ class RenameWiki extends Maintenance {
 			// let's count down JUST to be safe!
 			$this->countDown( 10 );
 
-			$hookRunner = $this->getServiceContainer()->get( 'CreateWikiHookRunner' );
 			$wikiManagerFactory = $this->getServiceContainer()->get( 'WikiManagerFactory' );
 			$wikiManager = $wikiManagerFactory->newInstance( $oldwiki );
 			$rename = $wikiManager->rename( newDatabaseName: $newwiki );
@@ -50,11 +49,6 @@ class RenameWiki extends Maintenance {
 			if ( $rename ) {
 				$this->fatalError( $rename );
 			}
-
-			$databaseUtils = $this->getServiceContainer()->get( 'CreateWikiDatabaseUtils' );
-			$dbw = $databaseUtils->getGlobalPrimaryDB();
-
-			$hookRunner->onCreateWikiRename( $dbw, $oldwiki, $newwiki );
 
 			$renamedWiki[] = $oldwiki;
 			$renamedWiki[] = $newwiki;


### PR DESCRIPTION
Already runs in WikiManagerFactory::rename(), we don't need to have it run twice.