### PR TITLE
Cleanup/modernize maintenance scripts

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -340,7 +340,7 @@
 			"value": false
 		},
 		"CreateWikiEnableManageInactiveWikis": {
-			"description": "Boolean. Whether the manageInactiveWikis.php maintenance script be enabled. That script marks wikis as inactive, closed, or deleted per $wgCreateWikiStateDays.",
+			"description": "Boolean. Whether the ManageInactiveWikis maintenance script be enabled. That script marks wikis as inactive, closed, or deleted per $wgCreateWikiStateDays.",
 			"value": false
 		},
 		"CreateWikiEnableRESTAPI": {

--- a/includes/Services/WikiManagerFactory.php
+++ b/includes/Services/WikiManagerFactory.php
@@ -16,6 +16,8 @@ use MediaWiki\User\UserFactory;
 use MessageLocalizer;
 use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
+use Miraheze\CreateWiki\Maintenance\PopulateMainPage;
+use Miraheze\CreateWiki\Maintenance\SetContainersAccess;
 use Wikimedia\Rdbms\DBConnRef;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\LBFactoryMulti;
@@ -224,12 +226,12 @@ class WikiManagerFactory {
 				$limits = [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ];
 
 				Shell::makeScriptCommand(
-					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/setContainersAccess.php',
+					SetContainersAccess::class,
 					[ '--wiki', $this->dbname ]
 				)->limits( $limits )->execute();
 
 				Shell::makeScriptCommand(
-					MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/populateMainPage.php',
+					PopulateMainPage::class,
 					[ '--wiki', $this->dbname ]
 				)->limits( $limits )->execute();
 

--- a/maintenance/ChangeDBCluster.php
+++ b/maintenance/ChangeDBCluster.php
@@ -54,5 +54,7 @@ class ChangeDBCluster extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = ChangeDBCluster::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ChangeDBCluster.php
+++ b/maintenance/ChangeDBCluster.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 

--- a/maintenance/ChangeDBCluster.php
+++ b/maintenance/ChangeDBCluster.php
@@ -54,7 +54,4 @@ class ChangeDBCluster extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = ChangeDBCluster::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return ChangeDBCluster::class;

--- a/maintenance/ChangeDBCluster.php
+++ b/maintenance/ChangeDBCluster.php
@@ -54,4 +54,6 @@ class ChangeDBCluster extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return ChangeDBCluster::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -45,7 +45,4 @@ class CheckLastWikiActivity extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = CheckLastWikiActivity::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return CheckLastWikiActivity::class;

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -45,5 +45,7 @@ class CheckLastWikiActivity extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = CheckLastWikiActivity::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -45,4 +45,6 @@ class CheckLastWikiActivity extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return CheckLastWikiActivity::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class CheckLastWikiActivity extends Maintenance {

--- a/maintenance/CreatePersistentModel.php
+++ b/maintenance/CreatePersistentModel.php
@@ -83,5 +83,7 @@ class CreatePersistentModel extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = CreatePersistentModel::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CreatePersistentModel.php
+++ b/maintenance/CreatePersistentModel.php
@@ -83,4 +83,6 @@ class CreatePersistentModel extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return CreatePersistentModel::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CreatePersistentModel.php
+++ b/maintenance/CreatePersistentModel.php
@@ -83,7 +83,4 @@ class CreatePersistentModel extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = CreatePersistentModel::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return CreatePersistentModel::class;

--- a/maintenance/CreatePersistentModel.php
+++ b/maintenance/CreatePersistentModel.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Services\WikiRequestManager;

--- a/maintenance/DeleteWiki.php
+++ b/maintenance/DeleteWiki.php
@@ -41,4 +41,6 @@ class DeleteWiki extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return DeleteWiki::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/DeleteWiki.php
+++ b/maintenance/DeleteWiki.php
@@ -41,5 +41,7 @@ class DeleteWiki extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = DeleteWiki::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/DeleteWiki.php
+++ b/maintenance/DeleteWiki.php
@@ -41,7 +41,4 @@ class DeleteWiki extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = DeleteWiki::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return DeleteWiki::class;

--- a/maintenance/DeleteWiki.php
+++ b/maintenance/DeleteWiki.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class DeleteWiki extends Maintenance {

--- a/maintenance/DeleteWikis.php
+++ b/maintenance/DeleteWikis.php
@@ -81,5 +81,7 @@ class DeleteWikis extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = DeleteWikis::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/DeleteWikis.php
+++ b/maintenance/DeleteWikis.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class DeleteWikis extends Maintenance {

--- a/maintenance/DeleteWikis.php
+++ b/maintenance/DeleteWikis.php
@@ -81,7 +81,4 @@ class DeleteWikis extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = DeleteWikis::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return DeleteWikis::class;

--- a/maintenance/DeleteWikis.php
+++ b/maintenance/DeleteWikis.php
@@ -81,4 +81,6 @@ class DeleteWikis extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return DeleteWikis::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateMissingCache.php
+++ b/maintenance/GenerateMissingCache.php
@@ -31,7 +31,4 @@ class GenerateMissingCache extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = GenerateMissingCache::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return GenerateMissingCache::class;

--- a/maintenance/GenerateMissingCache.php
+++ b/maintenance/GenerateMissingCache.php
@@ -31,5 +31,7 @@ class GenerateMissingCache extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = GenerateMissingCache::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateMissingCache.php
+++ b/maintenance/GenerateMissingCache.php
@@ -31,4 +31,6 @@ class GenerateMissingCache extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return GenerateMissingCache::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateMissingCache.php
+++ b/maintenance/GenerateMissingCache.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\CreateWiki\ConfigNames;

--- a/maintenance/ListDatabases.php
+++ b/maintenance/ListDatabases.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 

--- a/maintenance/ListDatabases.php
+++ b/maintenance/ListDatabases.php
@@ -21,7 +21,4 @@ class ListDatabases extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = ListDatabases::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return ListDatabases::class;

--- a/maintenance/ListDatabases.php
+++ b/maintenance/ListDatabases.php
@@ -21,5 +21,7 @@ class ListDatabases extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = ListDatabases::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ListDatabases.php
+++ b/maintenance/ListDatabases.php
@@ -21,4 +21,6 @@ class ListDatabases extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return ListDatabases::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ManageInactiveWikis.php
+++ b/maintenance/ManageInactiveWikis.php
@@ -199,5 +199,7 @@ class ManageInactiveWikis extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = ManageInactiveWikis::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ManageInactiveWikis.php
+++ b/maintenance/ManageInactiveWikis.php
@@ -199,4 +199,6 @@ class ManageInactiveWikis extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return ManageInactiveWikis::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ManageInactiveWikis.php
+++ b/maintenance/ManageInactiveWikis.php
@@ -199,7 +199,4 @@ class ManageInactiveWikis extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = ManageInactiveWikis::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return ManageInactiveWikis::class;

--- a/maintenance/ManageInactiveWikis.php
+++ b/maintenance/ManageInactiveWikis.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Services\RemoteWikiFactory;
@@ -72,10 +69,7 @@ class ManageInactiveWikis extends Maintenance {
 		$canWrite = $this->hasOption( 'write' );
 
 		/** @var CheckLastWikiActivity $activity */
-		$activity = $this->createChild(
-			CheckLastWikiActivity::class,
-			MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/CheckLastWikiActivity.php'
-		);
+		$activity = $this->createChild( CheckLastWikiActivity::class );
 		'@phan-var CheckLastWikiActivity $activity';
 
 		$activity->loadParamsAndArgs( null, [ 'quiet' => true ] );

--- a/maintenance/PopulateCentralWiki.php
+++ b/maintenance/PopulateCentralWiki.php
@@ -74,5 +74,7 @@ class PopulateCentralWiki extends LoggedUpdateMaintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = PopulateCentralWiki::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateCentralWiki.php
+++ b/maintenance/PopulateCentralWiki.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\LoggedUpdateMaintenance;
 use Miraheze\CreateWiki\ConfigNames;

--- a/maintenance/PopulateCentralWiki.php
+++ b/maintenance/PopulateCentralWiki.php
@@ -74,4 +74,6 @@ class PopulateCentralWiki extends LoggedUpdateMaintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return PopulateCentralWiki::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateCentralWiki.php
+++ b/maintenance/PopulateCentralWiki.php
@@ -74,7 +74,4 @@ class PopulateCentralWiki extends LoggedUpdateMaintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = PopulateCentralWiki::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return PopulateCentralWiki::class;

--- a/maintenance/PopulateMainPage.php
+++ b/maintenance/PopulateMainPage.php
@@ -48,5 +48,7 @@ class PopulateMainPage extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = PopulateMainPage::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateMainPage.php
+++ b/maintenance/PopulateMainPage.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\WikitextContent;
 use MediaWiki\MainConfigNames;

--- a/maintenance/PopulateMainPage.php
+++ b/maintenance/PopulateMainPage.php
@@ -48,4 +48,6 @@ class PopulateMainPage extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return PopulateMainPage::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateMainPage.php
+++ b/maintenance/PopulateMainPage.php
@@ -48,7 +48,4 @@ class PopulateMainPage extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = PopulateMainPage::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return PopulateMainPage::class;

--- a/maintenance/RebuildExtensionListCache.php
+++ b/maintenance/RebuildExtensionListCache.php
@@ -49,5 +49,7 @@ class RebuildExtensionListCache extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = RebuildExtensionListCache::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RebuildExtensionListCache.php
+++ b/maintenance/RebuildExtensionListCache.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\Registration\ExtensionProcessor;

--- a/maintenance/RebuildExtensionListCache.php
+++ b/maintenance/RebuildExtensionListCache.php
@@ -49,7 +49,4 @@ class RebuildExtensionListCache extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = RebuildExtensionListCache::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return RebuildExtensionListCache::class;

--- a/maintenance/RebuildExtensionListCache.php
+++ b/maintenance/RebuildExtensionListCache.php
@@ -49,4 +49,6 @@ class RebuildExtensionListCache extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return RebuildExtensionListCache::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RenameWiki.php
+++ b/maintenance/RenameWiki.php
@@ -79,5 +79,7 @@ class RenameWiki extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = RenameWiki::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RenameWiki.php
+++ b/maintenance/RenameWiki.php
@@ -79,4 +79,6 @@ class RenameWiki extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return RenameWiki::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RenameWiki.php
+++ b/maintenance/RenameWiki.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class RenameWiki extends Maintenance {

--- a/maintenance/RenameWiki.php
+++ b/maintenance/RenameWiki.php
@@ -79,7 +79,4 @@ class RenameWiki extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = RenameWiki::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return RenameWiki::class;

--- a/maintenance/SetContainersAccess.php
+++ b/maintenance/SetContainersAccess.php
@@ -73,7 +73,4 @@ class SetContainersAccess extends Maintenance {
 	}
 }
 
-// @codeCoverageIgnoreStart
-$maintClass = SetContainersAccess::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
-// @codeCoverageIgnoreEnd
+return SetContainersAccess::class;

--- a/maintenance/SetContainersAccess.php
+++ b/maintenance/SetContainersAccess.php
@@ -73,5 +73,7 @@ class SetContainersAccess extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = SetContainersAccess::class;
 require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreEnd

--- a/maintenance/SetContainersAccess.php
+++ b/maintenance/SetContainersAccess.php
@@ -73,4 +73,6 @@ class SetContainersAccess extends Maintenance {
 	}
 }
 
+// @codeCoverageIgnoreStart
 return SetContainersAccess::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/SetContainersAccess.php
+++ b/maintenance/SetContainersAccess.php
@@ -2,9 +2,6 @@
 
 namespace Miraheze\CreateWiki\Maintenance;
 
-$IP ??= getenv( 'MW_INSTALL_PATH' ) ?: dirname( __DIR__, 3 );
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\CreateWiki\ConfigNames;


### PR DESCRIPTION
### Maintenance Scripts Now Require `run.php`

Maintenance scripts **can no longer be run directly** by passing them to the PHP interpreter. Instead, they now **require** `run.php`.

#### New Usage:
Scripts can now be executed using either of the following methods:

- **Without PHP explicitly:**
  ```sh
  maintenance/run CreateWiki:ListDatabases
  ```
- **Using PHP:**
  ```sh
  php maintenance/run.php CreateWiki:ListDatabases
  ```

This change significantly simplifies calling maintenance scripts, reducing the steps needed.

#### Impact on Miraheze:

For Miraheze, this means scripts can now be executed using mwscript more conveniently. For example:

```sh
mwscript CreateWiki:ListDatabases
```