### PR TITLE
Optimize CheckLastWikiActivity

### DIFF
--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -26,7 +26,6 @@ class CheckLastWikiActivity extends Maintenance {
 		$revTimestamp = $dbr->newSelectQueryBuilder()
 			->select( 'MAX(rev_timestamp)' )
 			->from( 'revision' )
-			->useIndex( 'rev_timestamp' )
 			->caller( __METHOD__ )
 			->fetchField();
 

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -22,26 +22,20 @@ class CheckLastWikiActivity extends Maintenance {
 	public function getTimestamp(): int {
 		$dbr = $this->getDB( DB_REPLICA );
 
-		// Get the latest revision timestamp
-		$revTimestamp = $dbr->newSelectQueryBuilder()
-			->select( 'MAX(rev_timestamp)' )
-			->from( 'revision' )
+		$query = $dbr->newSelectQueryBuilder()
+			->select(
+				'GREATEST(
+					(SELECT MAX(rev_timestamp) FROM ' . $dbr->tableName( 'revision' ) . '),
+					(
+     						SELECT MAX(log_timestamp) FROM ' . $dbr->tableName( 'logging' ) .
+						' WHERE log_type NOT IN ("renameuser", "newusers")
+					)
+				) AS latest'
+			)
 			->caller( __METHOD__ )
 			->fetchField();
 
-		// Get the latest logging timestamp
-		$logTimestamp = $dbr->newSelectQueryBuilder()
-			->select( 'MAX(log_timestamp)' )
-			->from( 'logging' )
-			->where( [
-				$dbr->expr( 'log_type', '!=', 'renameuser' ),
-				$dbr->expr( 'log_type', '!=', 'newusers' ),
-			] )
-			->caller( __METHOD__ )
-			->fetchField();
-
-		// Return the most recent timestamp in either revision or logging
-		return (int)max( $revTimestamp, $logTimestamp );
+		return (int)( $query ?? 0 );
 	}
 }
 

--- a/maintenance/CheckLastWikiActivity.php
+++ b/maintenance/CheckLastWikiActivity.php
@@ -3,6 +3,7 @@
 namespace Miraheze\CreateWiki\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 class CheckLastWikiActivity extends Maintenance {
 
@@ -24,20 +25,23 @@ class CheckLastWikiActivity extends Maintenance {
 
 		// Get the latest revision timestamp
 		$revTimestamp = $dbr->newSelectQueryBuilder()
-			->select( 'MAX(rev_timestamp)' )
+			->select( 'rev_timestamp' )
 			->from( 'revision' )
+			->orderBy( 'rev_timestamp', SelectQueryBuilder::SORT_DESC )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchField();
 
 		// Get the latest logging timestamp
 		$logTimestamp = $dbr->newSelectQueryBuilder()
-			->select( 'MAX(log_timestamp)' )
+			->select( 'log_timestamp' )
 			->from( 'logging' )
 			->where( [
 				$dbr->expr( 'log_type', '!=', 'renameuser' ),
 				$dbr->expr( 'log_type', '!=', 'newusers' ),
 			] )
-			->useIndex( 'log_type_time' )
+			->orderBy( 'log_timestamp', SelectQueryBuilder::SORT_DESC )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchField();
 


### PR DESCRIPTION
Improves performance by about 898 times(!) according to profiling I did:
```shell
stdClass Object
(
    [Query_ID] => 1
    [Duration] => 1.00628092
    [Query] => SELECT /* MwSql::sqlDoQuery  */ MAX(log_timestamp) FROM logging WHERE log_type != 'renameuser' AND log_type != 'newusers'
)
stdClass Object
(
    [Query_ID] => 2
    [Duration] => 0.00112031
    [Query] => SELECT /* MwSql::sqlDoQuery  */ log_timestamp FROM logging WHERE log_type != 'renameuser' AND log_type != 'newusers' ORDER BY log_timestamp DESC LIMIT 1
)
```
1.00628092s -> 0.00112031s