### PR TITLE
Add an interface for config modules

### DIFF
--- a/includes/ConfigModuleInterface.php
+++ b/includes/ConfigModuleInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Miraheze\CreateWiki;
+
+interface ConfigModuleInterface {
+
+	public function hasChanges(): bool;
+
+	public function getErrors(): array;
+
+	public function setLogAction( string $action ): void;
+
+	public function getLogAction(): ?string;
+
+	public function addLogParam( string $param, mixed $value ): void;
+
+	public function getLogParams(): array;
+
+	public function commit(): void;
+}

--- a/includes/IConfigModule.php
+++ b/includes/IConfigModule.php
@@ -4,9 +4,9 @@ namespace Miraheze\CreateWiki;
 
 interface IConfigModule {
 
-	public function hasChanges(): bool;
-
 	public function getErrors(): array;
+
+	public function hasChanges(): bool;
 
 	public function setLogAction( string $action ): void;
 

--- a/includes/IConfigModule.php
+++ b/includes/IConfigModule.php
@@ -2,7 +2,7 @@
 
 namespace Miraheze\CreateWiki;
 
-interface ConfigModuleInterface {
+interface IConfigModule {
 
 	public function hasChanges(): bool;
 

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -5,15 +5,15 @@ namespace Miraheze\CreateWiki\Services;
 use JobSpecification;
 use MediaWiki\Config\ServiceOptions;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
-use Miraheze\CreateWiki\ConfigModuleInterface;
 use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Exceptions\MissingWikiError;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
+use Miraheze\CreateWiki\IConfigModule;
 use Miraheze\CreateWiki\Jobs\SetContainersAccessJob;
 use UnexpectedValueException;
 use Wikimedia\Rdbms\IReadableDatabase;
 
-class RemoteWikiFactory implements ConfigModuleInterface {
+class RemoteWikiFactory implements IConfigModule {
 
 	public const CONSTRUCTOR_OPTIONS = [
 		ConfigNames::UseClosedWikis,

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -419,14 +419,14 @@ class RemoteWikiFactory implements IConfigModule {
 		$this->newRows[$row] = $value;
 	}
 
-	public function hasChanges(): bool {
-		return (bool)$this->changes;
-	}
-
 	public function getErrors(): array {
 		// This class doesn't produce errors, but the method
 		// may be called by consumers, so return an empty array.
 		return [];
+	}
+
+	public function hasChanges(): bool {
+		return (bool)$this->changes;
 	}
 
 	public function setLogAction( string $action ): void {

--- a/includes/Services/RemoteWikiFactory.php
+++ b/includes/Services/RemoteWikiFactory.php
@@ -5,6 +5,7 @@ namespace Miraheze\CreateWiki\Services;
 use JobSpecification;
 use MediaWiki\Config\ServiceOptions;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
+use Miraheze\CreateWiki\ConfigModuleInterface;
 use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Exceptions\MissingWikiError;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
@@ -12,7 +13,7 @@ use Miraheze\CreateWiki\Jobs\SetContainersAccessJob;
 use UnexpectedValueException;
 use Wikimedia\Rdbms\IReadableDatabase;
 
-class RemoteWikiFactory {
+class RemoteWikiFactory implements ConfigModuleInterface {
 
 	public const CONSTRUCTOR_OPTIONS = [
 		ConfigNames::UseClosedWikis,
@@ -66,7 +67,6 @@ class RemoteWikiFactory {
 
 	public function newInstance( string $wiki ): self {
 		$this->dbr = $this->databaseUtils->getGlobalReplicaDB();
-
 		$row = $this->dbr->newSelectQueryBuilder()
 			->select( '*' )
 			->from( 'cw_wikis' )
@@ -205,7 +205,7 @@ class RemoteWikiFactory {
 	}
 
 	public function setInactiveExemptReason( string $reason ): void {
-		$reason = ( $reason === '' ) ? null : $reason;
+		$reason = $reason === '' ? null : $reason;
 
 		$this->trackChange( 'inactive-exempt-reason', $this->inactiveExemptReason, $reason );
 
@@ -344,7 +344,7 @@ class RemoteWikiFactory {
 	}
 
 	public function setServerName( string $server ): void {
-		$server = ( $server === '' ) ? null : $server;
+		$server = $server === '' ? null : $server;
 
 		$this->trackChange( 'servername', $this->url, $server );
 
@@ -402,46 +402,53 @@ class RemoteWikiFactory {
 		$this->newRows['wiki_extra'] = $newExtra;
 	}
 
+	public function disableResetDatabaseLists(): void {
+		$this->resetDatabaseLists = false;
+	}
+
+	/** @private Use extra field data */
 	public function trackChange( string $field, mixed $oldValue, mixed $newValue ): void {
 		$this->changes[$field] = [
 			'old' => $oldValue,
-			'new' => $newValue
+			'new' => $newValue,
 		];
+	}
+
+	/** @deprecated Use extra field data */
+	public function addNewRow( string $row, mixed $value ): void {
+		$this->newRows[$row] = $value;
 	}
 
 	public function hasChanges(): bool {
 		return (bool)$this->changes;
 	}
 
-	public function addNewRow( string $row, mixed $value ): void {
-		$this->newRows[$row] = $value;
+	public function getErrors(): array {
+		// This class doesn't produce errors, but the method
+		// may be called by consumers, so return an empty array.
+		return [];
 	}
 
 	public function setLogAction( string $action ): void {
 		$this->log = $action;
 	}
 
-	public function addLogParam( string $param, mixed $value ): void {
-		$this->logParams[$param] = $value;
-	}
-
 	public function getLogAction(): ?string {
 		return $this->log;
+	}
+
+	public function addLogParam( string $param, mixed $value ): void {
+		$this->logParams[$param] = $value;
 	}
 
 	public function getLogParams(): array {
 		return $this->logParams;
 	}
 
-	public function disableResetDatabaseLists(): void {
-		$this->resetDatabaseLists = false;
-	}
-
 	public function commit(): void {
 		if ( $this->hasChanges() ) {
 			if ( $this->newRows ) {
 				$dbw = $this->databaseUtils->getGlobalPrimaryDB();
-
 				$dbw->newUpdateQueryBuilder()
 					->update( 'cw_wikis' )
 					->set( $this->newRows )
@@ -465,7 +472,7 @@ class RemoteWikiFactory {
 						$this->hookRunner->onCreateWikiStatePrivate( $this->dbname );
 						break;
 					default:
-						throw new UnexpectedValueException( 'Unsupported hook: ' . $hook );
+						throw new UnexpectedValueException( "Unsupported hook: $hook" );
 				}
 			}
 
@@ -473,12 +480,13 @@ class RemoteWikiFactory {
 			if ( $this->resetDatabaseLists ) {
 				$data->resetDatabaseLists( isNewChanges: true );
 			}
+
 			$data->resetWikiData( isNewChanges: true );
 
 			if ( $this->log === null ) {
 				$this->log = 'settings';
 				$this->logParams = [
-					'5::changes' => implode( ', ', array_keys( $this->changes ) )
+					'5::changes' => implode( ', ', array_keys( $this->changes ) ),
 				];
 			}
 		}

--- a/tests/phpunit/Services/RemoteWikiFactoryTest.php
+++ b/tests/phpunit/Services/RemoteWikiFactoryTest.php
@@ -427,6 +427,18 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * @covers ::addLogParam
+	 * @covers ::getLogParams
+	 */
+	public function testAddLogParam(): void {
+		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
+		$this->assertArrayEquals( [], $remoteWiki->getLogParams() );
+
+		$remoteWiki->addLogParam( 'test', true );
+		$this->assertTrue( $remoteWiki->getLogParams()['test'] );
+	}
+
+	/**
 	 * @covers ::commit
 	 */
 	public function testCommit(): void {

--- a/tests/phpunit/Services/RemoteWikiFactoryTest.php
+++ b/tests/phpunit/Services/RemoteWikiFactoryTest.php
@@ -8,6 +8,7 @@ use Miraheze\CreateWiki\ConfigNames;
 use Miraheze\CreateWiki\Exceptions\MissingWikiError;
 use Miraheze\CreateWiki\Services\RemoteWikiFactory;
 use Miraheze\CreateWiki\Services\WikiManagerFactory;
+use Wikimedia\TestingAccessWrapper;
 use Wikimedia\Timestamp\ConvertibleTimestamp;
 
 /**

--- a/tests/phpunit/Services/RemoteWikiFactoryTest.php
+++ b/tests/phpunit/Services/RemoteWikiFactoryTest.php
@@ -121,6 +121,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getSitename
 	 * @covers ::setSitename
+	 * @covers ::trackChange
 	 */
 	public function testSetSitename(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -136,6 +137,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getLanguage
 	 * @covers ::setLanguage
+	 * @covers ::trackChange
 	 */
 	public function testSetLanguage(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -152,6 +154,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::isInactive
 	 * @covers ::markActive
 	 * @covers ::markInactive
+	 * @covers ::trackChange
 	 */
 	public function testMarkInactive(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -173,6 +176,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::isInactiveExempt
 	 * @covers ::markExempt
 	 * @covers ::unExempt
+	 * @covers ::trackChange
 	 */
 	public function testMarkExempt(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -193,6 +197,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getInactiveExemptReason
 	 * @covers ::setInactiveExemptReason
+	 * @covers ::trackChange
 	 */
 	public function testSetInactiveExemptReason(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -209,6 +214,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::isPrivate
 	 * @covers ::markPrivate
 	 * @covers ::markPublic
+	 * @covers ::trackChange
 	 */
 	public function testMarkPrivate(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -229,6 +235,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::isClosed
 	 * @covers ::markClosed
+	 * @covers ::trackChange
 	 */
 	public function testMarkClosed(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -250,6 +257,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::delete
 	 * @covers ::isDeleted
 	 * @covers ::undelete
+	 * @covers ::trackChange
 	 */
 	public function testDelete(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -271,6 +279,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::isLocked
 	 * @covers ::lock
 	 * @covers ::unlock
+	 * @covers ::trackChange
 	 */
 	public function testLock(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -291,6 +300,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getCategory
 	 * @covers ::setCategory
+	 * @covers ::trackChange
 	 */
 	public function testSetCategory(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -306,6 +316,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getServerName
 	 * @covers ::setServerName
+	 * @covers ::trackChange
 	 */
 	public function testSetServerName(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -321,6 +332,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getDBCluster
 	 * @covers ::setDBCluster
+	 * @covers ::trackChange
 	 */
 	public function testSetDBCluster(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -337,6 +349,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	 * @covers ::isExperimental
 	 * @covers ::markExperimental
 	 * @covers ::unMarkExperimental
+	 * @covers ::trackChange
 	 */
 	public function testMarkExperimental(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -357,6 +370,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers ::getExtraFieldData
 	 * @covers ::setExtraFieldData
+	 * @covers ::trackChange
 	 */
 	public function testSetExtraFieldData(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
@@ -390,6 +404,25 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
 		$this->assertSame( 'validnew', $remoteWiki->getExtraFieldData( 'test' ) );
 		$this->assertSame( 'valid2', $remoteWiki->getExtraFieldData( 'test2' ) );
+	}
+
+	/**
+	 * @covers ::disableResetDatabaseLists
+	 */
+	public function testDisableResetDatabaseLists(): void {
+		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
+		$remoteWiki->disableResetDatabaseLists();
+		$this->assertFalse(
+			TestingAccessWrapper::newFromObject( $remoteWiki )->resetDatabaseLists
+		);
+	}
+
+	/**
+	 * @covers ::getErrors
+	 */
+	public function testGetErrors(): void {
+		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
+		$this->assertArrayEquals( [], $remoteWiki->getErrors() );
 	}
 
 	/**

--- a/tests/phpunit/Services/RemoteWikiFactoryTest.php
+++ b/tests/phpunit/Services/RemoteWikiFactoryTest.php
@@ -427,6 +427,18 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 	}
 
 	/**
+	 * @covers ::getLogAction
+	 * @covers ::setLogAction
+	 */
+	public function testSetLogAction(): void {
+		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );
+		$this->assertNull( $remoteWiki->getLogAction() );
+
+		$remoteWiki->setLogAction( 'test', true );
+		$this->assertSame( 'test', $remoteWiki->getLogAction() );
+	}
+
+	/**
 	 * @covers ::addLogParam
 	 * @covers ::getLogParams
 	 */
@@ -440,6 +452,7 @@ class RemoteWikiFactoryTest extends MediaWikiIntegrationTestCase {
 
 	/**
 	 * @covers ::commit
+	 * @covers ::hasChanges
 	 */
 	public function testCommit(): void {
 		$remoteWiki = $this->getFactoryService()->newInstance( 'remotewikifactorytest' );


### PR DESCRIPTION
Can be used for all the ManageWiki module helpers as well, which all of those, along with RemoteWikiFactory require some common methods to be implemented, so we make an interface to do that.