### PR TITLE
Run void hooks as non-abortable

### DIFF
--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -36,7 +36,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiAfterCreationWithExtraData( array $extraData, string $dbname ): void {
 		$this->hookContainer->run(
 			'CreateWikiAfterCreationWithExtraData',
-			[ $extraData, $dbname ]
+			[ $extraData, $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -44,7 +45,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiCreationExtraFields( array &$extraFields ): void {
 		$this->hookContainer->run(
 			'CreateWikiCreationExtraFields',
-			[ &$extraFields ]
+			[ &$extraFields ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -52,7 +54,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiCreation( string $dbname, bool $private ): void {
 		$this->hookContainer->run(
 			'CreateWikiCreation',
-			[ $dbname, $private ]
+			[ $dbname, $private ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -64,7 +67,8 @@ class CreateWikiHookRunner implements
 	): void {
 		$this->hookContainer->run(
 			'CreateWikiDataFactoryBuilder',
-			[ $wiki, $dbr, &$cacheArray ]
+			[ $wiki, $dbr, &$cacheArray ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -75,7 +79,8 @@ class CreateWikiHookRunner implements
 	): void {
 		$this->hookContainer->run(
 			'CreateWikiDeletion',
-			[ $cwdb, $dbname ]
+			[ $cwdb, $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -83,7 +88,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiGenerateDatabaseLists( array &$databaseLists ): void {
 		$this->hookContainer->run(
 			'CreateWikiGenerateDatabaseLists',
-			[ &$databaseLists ]
+			[ &$databaseLists ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -91,7 +97,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiReadPersistentModel( string &$pipeline ): void {
 		$this->hookContainer->run(
 			'CreateWikiReadPersistentModel',
-			[ &$pipeline ]
+			[ &$pipeline ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -103,7 +110,8 @@ class CreateWikiHookRunner implements
 	): void {
 		$this->hookContainer->run(
 			'CreateWikiRename',
-			[ $cwdb, $oldDbName, $newDbName ]
+			[ $cwdb, $oldDbName, $newDbName ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -111,7 +119,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiStateClosed( string $dbname ): void {
 		$this->hookContainer->run(
 			'CreateWikiStateClosed',
-			[ $dbname ]
+			[ $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -119,7 +128,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiStateOpen( string $dbname ): void {
 		$this->hookContainer->run(
 			'CreateWikiStateOpen',
-			[ $dbname ]
+			[ $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -127,7 +137,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiStatePrivate( string $dbname ): void {
 		$this->hookContainer->run(
 			'CreateWikiStatePrivate',
-			[ $dbname ]
+			[ $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -135,7 +146,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiStatePublic( string $dbname ): void {
 		$this->hookContainer->run(
 			'CreateWikiStatePublic',
-			[ $dbname ]
+			[ $dbname ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -143,7 +155,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiTables( array &$tables ): void {
 		$this->hookContainer->run(
 			'CreateWikiTables',
-			[ &$tables ]
+			[ &$tables ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -151,7 +164,8 @@ class CreateWikiHookRunner implements
 	public function onCreateWikiWritePersistentModel( string $pipeline ): bool {
 		return $this->hookContainer->run(
 			'CreateWikiWritePersistentModel',
-			[ $pipeline ]
+			[ $pipeline ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -159,7 +173,8 @@ class CreateWikiHookRunner implements
 	public function onRequestWikiFormDescriptorModify( array &$formDescriptor ): void {
 		$this->hookContainer->run(
 			'RequestWikiFormDescriptorModify',
-			[ &$formDescriptor ]
+			[ &$formDescriptor ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -171,7 +186,8 @@ class CreateWikiHookRunner implements
 	): void {
 		$this->hookContainer->run(
 			'RequestWikiQueueFormDescriptorModify',
-			[ &$formDescriptor, $user, $wikiRequestManager ]
+			[ &$formDescriptor, $user, $wikiRequestManager ],
+			[ 'abortable' => false ]
 		);
 	}
 }


### PR DESCRIPTION
An upcoming MediaWiki core change ([I858d5dc02c](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1136337)) will enforce this in `HookRunnerTestBase`; given that the `HookContainer::run()` return value isn’t checked, these hooks were likely not meant to be abortable, though I confess I haven’t looked into it in detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal hook handling to improve consistency in option settings. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->