### PR TITLE
Bump dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "47.0.0",
-		"mediawiki/mediawiki-phan-config": "0.15.1",
+		"mediawiki/mediawiki-phan-config": "0.16.0",
 		"mediawiki/minus-x": "1.1.3",
-		"miraheze/phan-plugins": "0.1.0",
+		"miraheze/phan-plugins": "0.2.0",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"php-parallel-lint/php-parallel-lint": "1.4.0"
 	},


### PR DESCRIPTION
Bump miraheze/phan-plugins to 0.2.0 and mediawiki/mediawiki-phan-config to 0.16.0