### PR TITLE
Add new CreateWikiRemoteWikiCommit hook

### DIFF
--- a/includes/Helpers/RemoteWiki.php
+++ b/includes/Helpers/RemoteWiki.php
@@ -473,6 +473,7 @@ class RemoteWiki {
 			}
 
 			$data->resetWikiData( isNewChanges: true );
+			$this->hookRunner->onCreateWikiRemoteWikiCommit( $this->dbname );
 
 			if ( $this->log === null ) {
 				$this->log = 'settings';

--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -16,6 +16,7 @@ class CreateWikiHookRunner implements
 	CreateWikiDeletionHook,
 	CreateWikiGenerateDatabaseListsHook,
 	CreateWikiReadPersistentModelHook,
+	CreateWikiRemoteWikiCommitHook,
 	CreateWikiRenameHook,
 	CreateWikiStateClosedHook,
 	CreateWikiStateOpenHook,
@@ -98,6 +99,15 @@ class CreateWikiHookRunner implements
 		$this->hookContainer->run(
 			'CreateWikiReadPersistentModel',
 			[ &$pipeline ],
+			[ 'abortable' => false ]
+		);
+	}
+
+	/** @inheritDoc */
+	public function onCreateWikiRemoteWikiCommit( string $dbname ): void {
+		$this->hookContainer->run(
+			'CreateWikiRemoteWikiCommit',
+			[ $dbname ],
 			[ 'abortable' => false ]
 		);
 	}

--- a/includes/Hooks/CreateWikiRemoteWikiCommitHook.php
+++ b/includes/Hooks/CreateWikiRemoteWikiCommitHook.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Miraheze\CreateWiki\Hooks;
+
+interface CreateWikiRemoteWikiCommitHook {
+
+	/**
+	 * @param string $dbname
+	 *   The target wiki's database name (e.g., "examplewiki").
+	 *
+	 * @return void This hook must not abort, it must return no value.
+	 * @codeCoverageIgnore Cannot be annotated as covered.
+	 */
+	public function onCreateWikiRemoteWikiCommit( string $dbname ): void;
+}


### PR DESCRIPTION
This is a temporary hook during the migration of ManageWiki cache from CreateWiki to ManageWiki. After that is completed, the ManageWikiCoreProvider hook will be updated to pass DataStoreFactory as well, so that any providers can access it and reset the cache themselves when changes are committed or when needed.