### PR TITLE
Improve dark mode styling

### DIFF
--- a/modules/ext.createwiki.oouiform.ooui.less
+++ b/modules/ext.createwiki.oouiform.ooui.less
@@ -36,7 +36,7 @@
 
 .ext-createwiki-tabs-wrapper.oo-ui-panelLayout-framed,
 .ext-createwiki-tabs > .oo-ui-menuLayout-content > .oo-ui-indexLayout-stackLayout > .oo-ui-tabPanelLayout {
-	border-color: @border-color-base;
+	border-color: @border-color-subtle;
 }
 
 /* JavaScript disabled */
@@ -141,7 +141,7 @@
 				padding: 8px;
 				border: 1.5px solid @border-color-subtle;
 				border-radius: 4px;
-				background-color: @background-color-neutral;
+				background-color: @background-color-neutral-subtle;
 				color: @color-base;
 				font-family: 'Arial', sans-serif;
 				line-height: 1.5em;


### PR DESCRIPTION
Use codex design tokens to replace hard-coded colors for Special:RequestWikiQueue details.

Tested on Chrome/Firefox's dev tools.