### PR TITLE
Use 'reason' param if 'comment' is unset

### DIFF
--- a/includes/Notifications/EchoRequestDeclinedPresentationModel.php
+++ b/includes/Notifications/EchoRequestDeclinedPresentationModel.php
@@ -21,7 +21,7 @@ class EchoRequestDeclinedPresentationModel extends EchoEventPresentationModel {
 
 	/** @inheritDoc */
 	public function getBodyMessage(): RawMessage {
-		$comment = $this->event->getExtraParam( 'comment' );
+		$comment = $this->event->getExtraParam( 'comment' ) ?? $this->event->getExtraParam( 'reason' );
 		$text = DiscussionParser::getTextSnippet( $comment, $this->language );
 
 		return new RawMessage( '$1', [ $text ] );


### PR DESCRIPTION
The extra data key was changed but the existing event entries weren't migrated, which is causing exceptions since the 1.44 upgrade T14304