### PR TITLE
Use 'reason' param if 'comment' is unset in RequestMoreDetails notification

### DIFF
--- a/includes/Notifications/EchoRequestMoreDetailsPresentationModel.php
+++ b/includes/Notifications/EchoRequestMoreDetailsPresentationModel.php
@@ -21,7 +21,7 @@ class EchoRequestMoreDetailsPresentationModel extends EchoEventPresentationModel
 
 	/** @inheritDoc */
 	public function getBodyMessage(): RawMessage {
-		$comment = $this->event->getExtraParam( 'comment' ) ?? $this->event->getExtraParam( 'reason' );;
+		$comment = $this->event->getExtraParam( 'comment' ) ?? $this->event->getExtraParam( 'reason' );
 		$text = DiscussionParser::getTextSnippet( $comment, $this->language );
 
 		return new RawMessage( '$1', [ $text ] );

--- a/includes/Notifications/EchoRequestMoreDetailsPresentationModel.php
+++ b/includes/Notifications/EchoRequestMoreDetailsPresentationModel.php
@@ -21,7 +21,7 @@ class EchoRequestMoreDetailsPresentationModel extends EchoEventPresentationModel
 
 	/** @inheritDoc */
 	public function getBodyMessage(): RawMessage {
-		$comment = $this->event->getExtraParam( 'comment' );
+		$comment = $this->event->getExtraParam( 'comment' ) ?? $this->event->getExtraParam( 'reason' );;
 		$text = DiscussionParser::getTextSnippet( $comment, $this->language );
 
 		return new RawMessage( '$1', [ $text ] );


### PR DESCRIPTION
This fixes a regression introduced in fd12cecebdc6208e02d4da8a6279e5dc18ce2ab3.
Follow-up to 0b6468a

```
MessageCache::parseWithPostprocessing(): Argument #1 ($text) must be of type string, null given, called in /srv/mediawiki/1.44/extensions/Echo/includes/DiscussionParser.php on line 1279
from /srv/mediawiki/1.44/includes/language/MessageCache.php(1434)
#0 /srv/mediawiki/1.44/extensions/Echo/includes/DiscussionParser.php(1279): MessageCache->parseWithPostprocessing(null, MediaWiki\Page\PageReferenceValue, bool, bool, LanguageEn)
#1 /srv/mediawiki/1.44/extensions/CreateWiki/includes/Notifications/EchoRequestMoreDetailsPresentationModel.php(25): MediaWiki\Extension\Notifications\DiscussionParser::getTextSnippet(null, LanguageEn)
#2 /srv/mediawiki/1.44/extensions/Echo/includes/Formatters/EchoEventPresentationModel.php(570): Miraheze\CreateWiki\Notifications\EchoRequestMoreDetailsPresentationModel->getBodyMessage()
#3 /srv/mediawiki/1.44/extensions/Echo/includes/Formatters/EchoModelFormatter.php(14): MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel->jsonSerialize()
#4 /srv/mediawiki/1.44/extensions/Echo/includes/Formatters/EchoEventFormatter.php(77): MediaWiki\Extension\Notifications\Formatters\EchoModelFormatter->formatModel(Miraheze\CreateWiki\Notifications\EchoRequestMoreDetailsPresentationModel)
#5 /srv/mediawiki/1.44/extensions/Echo/includes/DataOutputFormatter.php(201): MediaWiki\Extension\Notifications\Formatters\EchoEventFormatter->format(MediaWiki\Extension\Notifications\Model\Event)
#6 /srv/mediawiki/1.44/extensions/Echo/includes/DataOutputFormatter.php(160): MediaWiki\Extension\Notifications\DataOutputFormatter::formatNotification(MediaWiki\Extension\Notifications\Model\Event, MediaWiki\User\User, string, LanguageEn)
#7 /srv/mediawiki/1.44/extensions/Echo/includes/Api/ApiEchoNotifications.php(324): MediaWiki\Extension\Notifications\DataOutputFormatter::formatOutput(MediaWiki\Extension\Notifications\Model\Notification, string, MediaWiki\User\User, LanguageEn)
#8 /srv/mediawiki/1.44/extensions/Echo/includes/Api/ApiEchoNotifications.php(132): MediaWiki\Extension\Notifications\Api\ApiEchoNotifications->getPropList(MediaWiki\User\User, array, array, int, null, string, null, bool, bool)
#9 /srv/mediawiki/1.44/extensions/Echo/includes/Api/ApiEchoNotifications.php(67): MediaWiki\Extension\Notifications\Api\ApiEchoNotifications->getLocalNotifications(array)
#10 /srv/mediawiki/1.44/includes/api/ApiQuery.php(739): MediaWiki\Extension\Notifications\Api\ApiEchoNotifications->execute()
#11 /srv/mediawiki/1.44/includes/api/ApiMain.php(2010): MediaWiki\Api\ApiQuery->execute()
#12 /srv/mediawiki/1.44/includes/api/ApiMain.php(948): MediaWiki\Api\ApiMain->executeAction()
#13 /srv/mediawiki/1.44/includes/api/ApiMain.php(919): MediaWiki\Api\ApiMain->executeActionWithErrorHandling()
#14 /srv/mediawiki/1.44/includes/api/ApiEntryPoint.php(152): MediaWiki\Api\ApiMain->execute()
#15 /srv/mediawiki/1.44/includes/MediaWikiEntryPoint.php(202): MediaWiki\Api\ApiEntryPoint->execute()
#16 /srv/mediawiki/1.44/api.php(44): MediaWiki\MediaWikiEntryPoint->run()
#17 /srv/mediawiki/config/initialise/entrypoints/api.php(3): require(string)
#18 {main}
```