### PR TITLE
Add a hook for modifying the Special:CreateWiki form

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -158,6 +158,7 @@
 			"class": "Miraheze\\CreateWiki\\Specials\\SpecialCreateWiki",
 			"services": [
 				"CreateWikiDatabaseUtils",
+				"CreateWikiHookRunner",
 				"CreateWikiValidator",
 				"WikiManagerFactory"
 			]

--- a/includes/Hooks/CreateWikiFormDescriptorModifyHook.php
+++ b/includes/Hooks/CreateWikiFormDescriptorModifyHook.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Miraheze\CreateWiki\Hooks;
+
+interface CreateWikiFormDescriptorModifyHook {
+
+	/**
+	 * @param array &$formDescriptor
+	 *   The HTMLForm descriptor array. This is passed by reference and may be modified
+	 *   to add new form fields or update existing ones. Array keys should be unique field names,
+	 *   and values should conform to HTMLForm field configuration.
+	 *
+	 * @return void This hook must not abort, it must return no value.
+	 * @codeCoverageIgnore Cannot be annotated as covered.
+	 */
+	public function onCreateWikiFormDescriptorModify( array &$formDescriptor ): void;
+}

--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -12,6 +12,7 @@ class CreateWikiHookRunner implements
 	CreateWikiCreationExtraFieldsHook,
 	CreateWikiCreationHook,
 	CreateWikiDeletionHook,
+	CreateWikiFormDescriptorModifyHook,
 	CreateWikiGenerateDatabaseListsHook,
 	CreateWikiReadPersistentModelHook,
 	CreateWikiRemoteWikiCommitHook,
@@ -45,6 +46,15 @@ class CreateWikiHookRunner implements
 		$this->hookContainer->run(
 			'CreateWikiCreationExtraFields',
 			[ &$extraFields ],
+			[ 'abortable' => false ]
+		);
+	}
+
+	/** @inheritDoc */
+	public function onCreateWikiFormDescriptorModify( array &$formDescriptor ): void {
+		$this->hookContainer->run(
+			'CreateWikiFormDescriptorModify',
+			[ &$formDescriptor ],
 			[ 'abortable' => false ]
 		);
 	}

--- a/includes/Specials/SpecialCreateWiki.php
+++ b/includes/Specials/SpecialCreateWiki.php
@@ -6,6 +6,7 @@ use MediaWiki\Exception\ErrorPageError;
 use MediaWiki\Html\Html;
 use MediaWiki\SpecialPage\FormSpecialPage;
 use Miraheze\CreateWiki\ConfigNames;
+use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
 use Miraheze\CreateWiki\Services\CreateWikiValidator;
 use Miraheze\CreateWiki\Services\WikiManagerFactory;
@@ -14,6 +15,7 @@ class SpecialCreateWiki extends FormSpecialPage {
 
 	public function __construct(
 		private readonly CreateWikiDatabaseUtils $databaseUtils,
+		private readonly CreateWikiHookRunner $hookRunner,
 		private readonly CreateWikiValidator $validator,
 		private readonly WikiManagerFactory $wikiManagerFactory,
 	) {
@@ -86,6 +88,8 @@ class SpecialCreateWiki extends FormSpecialPage {
 			'required' => true,
 			'useeditfont' => true,
 		];
+
+		$this->hookRunner->onCreateWikiFormDescriptorModify( $formDescriptor );
 
 		return $formDescriptor;
 	}


### PR DESCRIPTION
For the CreateWikiLoadout extension. 

It's also nice to be able to add additional fields to Special:CreateWiki if similar needs arise in the future.

Only tested on localhost. 