### PR TITLE
Allow deserializing ScalarParams in log entries

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -157,6 +157,41 @@
 			]
 		}
 	},
+	"LogParamsAllowedClasses": {
+		"farmer/comment": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/create-failure": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestapprove": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestabandon": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestdecline": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestonhold": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestreopen": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmer/requestmoredetails": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmersuppression/delete": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmersuppression/public": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"farmersuppression/suppress": [
+			"Wikimedia\\Message\\ScalarParam"
+		]
+	},
 	"SpecialPages": {
 		"CreateWiki": {
 			"class": "Miraheze\\CreateWiki\\Specials\\SpecialCreateWiki",


### PR DESCRIPTION
This is unfortunately a bit ugly, but wildcards aren't supported here: https://github.com/wikimedia/mediawiki/blob/6a03c5c6dddd6faf554459e288a63894f69dbaf1/includes/Logging/LogEntryBase.php#L63

https://issue-tracker.miraheze.org/T15802