### PR TITLE
display label instead of value in closure reason logging

### DIFF
--- a/includes/Helpers/RemoteWiki.php
+++ b/includes/Helpers/RemoteWiki.php
@@ -312,12 +312,12 @@ class RemoteWiki {
 	public function setClosedReason( string $reason ): void {
 		$reason = $reason === '' ? null : $reason;
 		$closedReasonOptions = $this->options->get( ConfigNames::ClosedReasonOptions );
-		
+
 		$this->trackChange( 'closed-reason', $this->closedReason, $reason );
 
 		$this->closedReason = $reason;
 		$this->newRows['wiki_closed_reason'] = $reason;
-		
+
 		$this->logParams['5::reason'] = $reason !== null
 			? ( $closedReasonOptions[$reason] ?? $reason )
 			: '';

--- a/includes/Helpers/RemoteWiki.php
+++ b/includes/Helpers/RemoteWiki.php
@@ -311,12 +311,16 @@ class RemoteWiki {
 
 	public function setClosedReason( string $reason ): void {
 		$reason = $reason === '' ? null : $reason;
-
+		$closedReasonOptions = $this->options->get( ConfigNames::ClosedReasonOptions );
+		
 		$this->trackChange( 'closed-reason', $this->closedReason, $reason );
 
 		$this->closedReason = $reason;
 		$this->newRows['wiki_closed_reason'] = $reason;
-		$this->logParams['5::reason'] = $reason ?? '';
+		
+		$this->logParams['5::reason'] = $reason !== null
+			? ( $closedReasonOptions[$reason] ?? $reason )
+			: '';
 	}
 
 	public function getClosedReason(): ?string {


### PR DESCRIPTION
[DO NOT REVIEW/MERGE, untested!]
I didn't think of this initially, logs currently look like this which isn't very nice: 15:29  Reception123 talk contribs block closed the wiki "vccbusinesswiki", Reason: cp-commercial (commercial "speech", links to external commercial websites, SEO spam)

We want to display the actual human readable label, not the value