### PR TITLE
Allow disabling main page creation with a hook

### DIFF
--- a/includes/Hooks/CreateWikiCreationOptionsHook.php
+++ b/includes/Hooks/CreateWikiCreationOptionsHook.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Miraheze\CreateWiki\Hooks;
+
+interface CreateWikiCreationOptionsHook {
+
+	/**
+	 * Allows modifying which of the built-in steps of the wiki creation process
+	 * are performed for a given wiki.
+	 *
+	 * Currently supported options:
+	 * 1. createMainPage (bool, default true): whether to populate the Main Page of
+	 *    the new wiki.
+	 *
+	 * @param string $dbname
+	 *   The created wiki's database name.
+	 * @param array $extra
+	 *   The extra data submitted with the wiki request from the
+	 *   CreateWikiCreationExtraFields hook.
+	 * @param array &$options
+	 *   Options to modify, as documented above.
+	 *
+	 * @return void This hook must not abort, it must return no value.
+	 * @codeCoverageIgnore Cannot be annotated as covered.
+	 */
+	public function onCreateWikiCreationOptions(
+		string $dbname,
+		array $extra,
+		array &$options
+	): void;
+}

--- a/includes/Hooks/CreateWikiHookRunner.php
+++ b/includes/Hooks/CreateWikiHookRunner.php
@@ -11,6 +11,7 @@ class CreateWikiHookRunner implements
 	CreateWikiAfterCreationWithExtraDataHook,
 	CreateWikiCreationExtraFieldsHook,
 	CreateWikiCreationHook,
+	CreateWikiCreationOptionsHook,
 	CreateWikiDeletionHook,
 	CreateWikiGenerateDatabaseListsHook,
 	CreateWikiReadPersistentModelHook,
@@ -54,6 +55,19 @@ class CreateWikiHookRunner implements
 		$this->hookContainer->run(
 			'CreateWikiCreation',
 			[ $dbname, $private ],
+			[ 'abortable' => false ]
+		);
+	}
+
+	/** @inheritDoc */
+	public function onCreateWikiCreationOptions(
+		string $dbname,
+		array $extra,
+		array &$options
+	): void {
+		$this->hookContainer->run(
+			'CreateWikiCreationOptions',
+			[ $dbname, $extra, &$options ],
 			[ 'abortable' => false ]
 		);
 	}

--- a/includes/Services/WikiManagerFactory.php
+++ b/includes/Services/WikiManagerFactory.php
@@ -263,8 +263,11 @@ class WikiManagerFactory {
 
 		$this->hookRunner->onCreateWikiCreation( $this->dbname, $private );
 
+		$creationOptions = [];
+		$this->hookRunner->onCreateWikiCreationOptions( $this->dbname, $extra, $creationOptions );
+
 		DeferredUpdates::addCallableUpdate(
-			function () use ( $requester, $extra ) {
+			function () use ( $requester, $extra, $creationOptions ) {
 				$this->dataStore->resetDatabaseLists( isNewChanges: true );
 				$limits = [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ];
 
@@ -273,7 +276,10 @@ class WikiManagerFactory {
 					[ '--wiki', $this->dbname ]
 				)->limits( $limits )->execute();
 
-				if ( !defined( 'MW_PHPUNIT_TEST' ) ) {
+				if (
+					( $creationOptions['createMainPage'] ?? true ) &&
+					!defined( 'MW_PHPUNIT_TEST' )
+				) {
 					Shell::makeScriptCommand(
 						PopulateMainPage::class,
 						[ '--wiki', $this->dbname ]


### PR DESCRIPTION
Currently only supports disabling main page creation.

Can be modified to support other features (e.g. executing extra SQL statements).